### PR TITLE
feat: add seo_head template tag

### DIFF
--- a/src/wagtail_herald/templates/wagtail_herald/seo_head.html
+++ b/src/wagtail_herald/templates/wagtail_herald/seo_head.html
@@ -1,0 +1,37 @@
+{# Basic Meta #}
+<title>{{ title }}</title>
+{% if description %}<meta name="description" content="{{ description }}">{% endif %}
+{% if robots %}<meta name="robots" content="{{ robots }}">{% endif %}
+{% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}">{% endif %}
+
+{# Open Graph #}
+<meta property="og:type" content="{{ og_type }}">
+{% if og_title %}<meta property="og:title" content="{{ og_title }}">{% endif %}
+{% if og_description %}<meta property="og:description" content="{{ og_description }}">{% endif %}
+{% if og_image %}<meta property="og:image" content="{{ og_image }}">{% endif %}
+{% if og_image_alt %}<meta property="og:image:alt" content="{{ og_image_alt }}">{% endif %}
+{% if og_image_width %}<meta property="og:image:width" content="{{ og_image_width }}">{% endif %}
+{% if og_image_height %}<meta property="og:image:height" content="{{ og_image_height }}">{% endif %}
+{% if og_url %}<meta property="og:url" content="{{ og_url }}">{% endif %}
+{% if og_site_name %}<meta property="og:site_name" content="{{ og_site_name }}">{% endif %}
+<meta property="og:locale" content="{{ og_locale }}">
+
+{# Twitter Card #}
+<meta name="twitter:card" content="{{ twitter_card }}">
+{% if twitter_site %}<meta name="twitter:site" content="@{{ twitter_site }}">{% endif %}
+{% if twitter_title %}<meta name="twitter:title" content="{{ twitter_title }}">{% endif %}
+{% if twitter_description %}<meta name="twitter:description" content="{{ twitter_description }}">{% endif %}
+{% if twitter_image %}<meta name="twitter:image" content="{{ twitter_image }}">{% endif %}
+{% if twitter_image_alt %}<meta name="twitter:image:alt" content="{{ twitter_image_alt }}">{% endif %}
+
+{# Favicon #}
+{% if favicon_svg %}<link rel="icon" type="image/svg+xml" href="{{ favicon_svg }}">{% endif %}
+{% if favicon_png %}<link rel="icon" type="image/png" sizes="48x48" href="{{ favicon_png }}">{% endif %}
+{% if apple_touch_icon %}<link rel="apple-touch-icon" sizes="180x180" href="{{ apple_touch_icon }}">{% endif %}
+
+{# Verification #}
+{% if google_verification %}<meta name="google-site-verification" content="{{ google_verification }}">{% endif %}
+{% if bing_verification %}<meta name="msvalidate.01" content="{{ bing_verification }}">{% endif %}
+
+{# Custom Head HTML - output raw, no escaping #}
+{% if custom_head_html %}{{ custom_head_html|safe }}{% endif %}

--- a/src/wagtail_herald/templatetags/__init__.py
+++ b/src/wagtail_herald/templatetags/__init__.py
@@ -1,0 +1,3 @@
+"""
+wagtail-herald template tags.
+"""

--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -1,0 +1,280 @@
+"""
+Template tags for wagtail-herald SEO output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django import template
+from django.http import HttpRequest
+from django.template.loader import render_to_string
+from django.utils.safestring import SafeString, mark_safe
+
+if TYPE_CHECKING:
+    from wagtail_herald.models import SEOSettings
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def seo_head(context: dict[str, Any]) -> SafeString:
+    """Output all SEO meta tags, OG tags, Twitter Card, favicons, and custom HTML.
+
+    Usage in templates:
+        {% load wagtail_herald %}
+        <head>
+            {% seo_head %}
+        </head>
+    """
+    request = context.get("request")
+    page = context.get("page") or context.get("self")
+
+    from wagtail_herald.models import SEOSettings
+
+    seo_settings = None
+    if request:
+        seo_settings = SEOSettings.for_request(request)
+
+    seo_context = build_seo_context(request, page, seo_settings)
+
+    return mark_safe(
+        render_to_string(
+            "wagtail_herald/seo_head.html",
+            seo_context,
+            request=request,
+        )
+    )
+
+
+def build_seo_context(
+    request: HttpRequest | None,
+    page: Any,
+    settings: SEOSettings | None,
+) -> dict[str, Any]:
+    """Build context dict for SEO template.
+
+    Args:
+        request: HTTP request object.
+        page: Wagtail page instance.
+        settings: SEOSettings instance.
+
+    Returns:
+        Dictionary with all SEO template variables.
+    """
+    site = getattr(request, "site", None) if request else None
+
+    # Title with separator
+    page_title = _get_page_title(page)
+    site_name = site.site_name if site else ""
+    separator = settings.title_separator if settings else "|"
+    full_title = f"{page_title} {separator} {site_name}" if site_name else page_title
+
+    # Description
+    description = getattr(page, "search_description", "") or ""
+
+    # Canonical URL
+    canonical_url = _get_canonical_url(request, page)
+
+    # Robots
+    robots = _get_robots_meta(page)
+
+    # OG Image with dimensions
+    og_image_data = _get_og_image_data(request, page, settings)
+
+    # Locale
+    locale = settings.default_locale if settings else "en_US"
+
+    # Favicon URLs
+    favicon_svg_url = _get_image_url(request, settings.favicon_svg) if settings else ""
+    favicon_png_url = _get_image_url(request, settings.favicon_png) if settings else ""
+    apple_touch_icon_url = (
+        _get_image_url(request, settings.apple_touch_icon) if settings else ""
+    )
+
+    return {
+        "title": full_title,
+        "description": description,
+        "canonical_url": canonical_url,
+        "robots": robots,
+        "og_type": "website",
+        "og_title": page_title,
+        "og_description": description,
+        "og_image": og_image_data.get("url"),
+        "og_image_alt": og_image_data.get("alt"),
+        "og_image_width": og_image_data.get("width"),
+        "og_image_height": og_image_data.get("height"),
+        "og_url": canonical_url,
+        "og_site_name": site_name,
+        "og_locale": locale,
+        "twitter_card": "summary_large_image",
+        "twitter_site": settings.twitter_handle if settings else "",
+        "twitter_title": page_title,
+        "twitter_description": description,
+        "twitter_image": og_image_data.get("url"),
+        "twitter_image_alt": og_image_data.get("alt"),
+        "favicon_svg": favicon_svg_url,
+        "favicon_png": favicon_png_url,
+        "apple_touch_icon": apple_touch_icon_url,
+        "google_verification": settings.google_site_verification if settings else "",
+        "bing_verification": settings.bing_site_verification if settings else "",
+        "custom_head_html": settings.custom_head_html if settings else "",
+    }
+
+
+def _get_page_title(page: Any) -> str:
+    """Get page title with seo_title fallback.
+
+    Args:
+        page: Wagtail page instance.
+
+    Returns:
+        Page title string.
+    """
+    if not page:
+        return ""
+    seo_title = getattr(page, "seo_title", None)
+    if seo_title:
+        return str(seo_title)
+    return str(getattr(page, "title", ""))
+
+
+def _get_canonical_url(request: HttpRequest | None, page: Any) -> str:
+    """Get canonical URL for page.
+
+    Uses page's get_canonical_url method if available (SEOPageMixin),
+    otherwise falls back to full_url.
+
+    Args:
+        request: HTTP request object.
+        page: Wagtail page instance.
+
+    Returns:
+        Canonical URL string.
+    """
+    if not page:
+        return ""
+
+    if hasattr(page, "get_canonical_url"):
+        return str(page.get_canonical_url(request))
+
+    return str(getattr(page, "full_url", ""))
+
+
+def _get_robots_meta(page: Any) -> str:
+    """Get robots meta content.
+
+    Uses page's get_robots_meta method if available (SEOPageMixin).
+
+    Args:
+        page: Wagtail page instance.
+
+    Returns:
+        Robots meta string (e.g., "noindex, nofollow") or empty string.
+    """
+    if not page:
+        return ""
+
+    if hasattr(page, "get_robots_meta"):
+        return str(page.get_robots_meta())
+
+    return ""
+
+
+def _get_og_image_data(
+    request: HttpRequest | None,
+    page: Any,
+    settings: SEOSettings | None,
+) -> dict[str, Any]:
+    """Get OG image data with fallback chain.
+
+    Priority: page.og_image → settings.default_og_image → None
+
+    Args:
+        request: HTTP request object.
+        page: Wagtail page instance.
+        settings: SEOSettings instance.
+
+    Returns:
+        Dict with url, alt, width, height keys.
+    """
+    image = None
+    alt_text = ""
+
+    # Try page-level og_image first
+    if page and hasattr(page, "og_image") and page.og_image:
+        image = page.og_image
+        if hasattr(page, "get_og_image_alt"):
+            alt_text = page.get_og_image_alt()
+        else:
+            alt_text = getattr(page, "og_image_alt", "") or ""
+
+    # Fall back to settings default_og_image
+    elif settings and settings.default_og_image:
+        image = settings.default_og_image
+        alt_text = settings.default_og_image_alt or ""
+
+    if not image:
+        return {"url": "", "alt": "", "width": "", "height": ""}
+
+    # Generate rendition for optimal OG size (1200x630)
+    try:
+        rendition = image.get_rendition("fill-1200x630")
+        url = _make_absolute_url(request, rendition.url)
+        return {
+            "url": url,
+            "alt": alt_text,
+            "width": rendition.width,
+            "height": rendition.height,
+        }
+    except Exception:
+        # Fallback to original image if rendition fails
+        url = _get_image_url(request, image)
+        return {
+            "url": url,
+            "alt": alt_text,
+            "width": getattr(image, "width", ""),
+            "height": getattr(image, "height", ""),
+        }
+
+
+def _get_image_url(request: HttpRequest | None, image: Any) -> str:
+    """Get absolute URL for an image.
+
+    Args:
+        request: HTTP request object.
+        image: Wagtail image instance.
+
+    Returns:
+        Absolute URL string or empty string.
+    """
+    if not image:
+        return ""
+
+    url = getattr(image, "url", "")
+    if hasattr(image, "file") and hasattr(image.file, "url"):
+        url = image.file.url
+
+    return _make_absolute_url(request, url)
+
+
+def _make_absolute_url(request: HttpRequest | None, url: str) -> str:
+    """Convert relative URL to absolute URL.
+
+    Args:
+        request: HTTP request object.
+        url: URL string (relative or absolute).
+
+    Returns:
+        Absolute URL string.
+    """
+    if not url:
+        return ""
+
+    if url.startswith(("http://", "https://")):
+        return url
+
+    if request and hasattr(request, "build_absolute_uri"):
+        return str(request.build_absolute_uri(url))
+
+    return url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,4 +56,8 @@ def site(db, root_page):
             "site_name": "Test Site",
         },
     )
+    # Ensure site_name is set even if site already existed
+    if site.site_name != "Test Site":
+        site.site_name = "Test Site"
+        site.save()
     return site

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,439 @@
+"""
+Tests for wagtail-herald template tags.
+"""
+
+from django.template import Context, Template
+
+from wagtail_herald.models import SEOSettings
+from wagtail_herald.templatetags.wagtail_herald import (
+    _get_canonical_url,
+    _get_og_image_data,
+    _get_page_title,
+    _get_robots_meta,
+    _make_absolute_url,
+    build_seo_context,
+)
+
+
+class TestSeoHeadTemplateTag:
+    """Tests for the seo_head template tag."""
+
+    def test_tag_is_registered(self):
+        """Test that seo_head tag can be loaded."""
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        assert template is not None
+
+    def test_tag_renders_without_context(self, rf, db, site):
+        """Test tag renders with minimal context."""
+        request = rf.get("/")
+        request.site = site
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request})
+        html = template.render(context)
+
+        assert "<title>" in html
+        assert 'property="og:type"' in html
+
+    def test_tag_renders_title(self, rf, site):
+        """Test tag renders page title."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert "<title>Test Page | Test Site</title>" in html
+
+    def test_tag_renders_seo_title_override(self, rf, site):
+        """Test tag uses seo_title when available."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Regular Title"
+            seo_title = "SEO Title"
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert "SEO Title | Test Site" in html
+
+    def test_tag_renders_description(self, rf, site):
+        """Test tag renders meta description."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = "This is a test description"
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'name="description"' in html
+        assert "This is a test description" in html
+
+    def test_tag_renders_og_tags(self, rf, site):
+        """Test tag renders Open Graph tags."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = "Test description"
+            full_url = "https://example.com/test/"
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'property="og:type" content="website"' in html
+        assert 'property="og:title" content="Test Page"' in html
+        assert 'property="og:locale"' in html
+
+    def test_tag_renders_twitter_card(self, rf, site):
+        """Test tag renders Twitter Card tags."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'name="twitter:card" content="summary_large_image"' in html
+
+    def test_tag_renders_twitter_site(self, rf, site, db):
+        """Test tag renders twitter:site when configured."""
+        SEOSettings.objects.create(site=site, twitter_handle="testhandle")
+
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'name="twitter:site" content="@testhandle"' in html
+
+    def test_tag_renders_robots_noindex(self, rf, site):
+        """Test tag renders robots meta for noindex pages."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+            noindex = True
+            nofollow = False
+
+            def get_robots_meta(self):
+                return "noindex"
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'name="robots" content="noindex"' in html
+
+    def test_tag_renders_canonical_url(self, rf, site):
+        """Test tag renders canonical link."""
+        request = rf.get("/test/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+            full_url = "https://example.com/test/"
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert 'rel="canonical"' in html
+        assert "https://example.com/test/" in html
+
+    def test_tag_renders_verification_codes(self, rf, site, db):
+        """Test tag renders site verification meta tags."""
+        SEOSettings.objects.create(
+            site=site,
+            google_site_verification="google123",
+            bing_site_verification="bing456",
+        )
+
+        request = rf.get("/")
+        request.site = site
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request})
+        html = template.render(context)
+
+        assert 'name="google-site-verification" content="google123"' in html
+        assert 'name="msvalidate.01" content="bing456"' in html
+
+    def test_tag_renders_custom_head_html(self, rf, site, db):
+        """Test tag renders custom head HTML."""
+        SEOSettings.objects.create(
+            site=site,
+            custom_head_html='<meta name="custom" content="value">',
+        )
+
+        request = rf.get("/")
+        request.site = site
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request})
+        html = template.render(context)
+
+        assert '<meta name="custom" content="value">' in html
+
+    def test_tag_uses_configured_separator(self, rf, site, db):
+        """Test tag uses configured title separator."""
+        SEOSettings.objects.create(site=site, title_separator="-")
+
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request, "page": MockPage()})
+        html = template.render(context)
+
+        assert "<title>Test Page - Test Site</title>" in html
+
+    def test_tag_uses_configured_locale(self, rf, site, db):
+        """Test tag uses configured default locale."""
+        SEOSettings.objects.create(site=site, default_locale="ja_JP")
+
+        request = rf.get("/")
+        request.site = site
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        context = Context({"request": request})
+        html = template.render(context)
+
+        assert 'property="og:locale" content="ja_JP"' in html
+
+
+class TestBuildSeoContext:
+    """Tests for build_seo_context function."""
+
+    def test_returns_dict(self, rf, site):
+        """Test function returns a dictionary."""
+        request = rf.get("/")
+        request.site = site
+        result = build_seo_context(request, None, None)
+        assert isinstance(result, dict)
+
+    def test_contains_required_keys(self, rf, site):
+        """Test result contains all required keys."""
+        request = rf.get("/")
+        request.site = site
+        result = build_seo_context(request, None, None)
+
+        required_keys = [
+            "title",
+            "description",
+            "canonical_url",
+            "robots",
+            "og_type",
+            "og_title",
+            "og_locale",
+            "twitter_card",
+        ]
+
+        for key in required_keys:
+            assert key in result
+
+    def test_handles_none_page(self, rf, site):
+        """Test function handles None page gracefully."""
+        request = rf.get("/")
+        request.site = site
+        result = build_seo_context(request, None, None)
+
+        assert result["title"] == " | Test Site"
+        assert result["og_title"] == ""
+
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_get_page_title_with_title(self):
+        """Test _get_page_title returns title."""
+
+        class MockPage:
+            title = "Page Title"
+            seo_title = ""
+
+        result = _get_page_title(MockPage())
+        assert result == "Page Title"
+
+    def test_get_page_title_prefers_seo_title(self):
+        """Test _get_page_title prefers seo_title."""
+
+        class MockPage:
+            title = "Page Title"
+            seo_title = "SEO Title"
+
+        result = _get_page_title(MockPage())
+        assert result == "SEO Title"
+
+    def test_get_page_title_with_none(self):
+        """Test _get_page_title handles None."""
+        result = _get_page_title(None)
+        assert result == ""
+
+    def test_get_canonical_url_uses_method(self, rf):
+        """Test _get_canonical_url uses page method."""
+        request = rf.get("/test/")
+
+        class MockPage:
+            def get_canonical_url(self, request):
+                return "https://example.com/canonical/"
+
+        result = _get_canonical_url(request, MockPage())
+        assert result == "https://example.com/canonical/"
+
+    def test_get_canonical_url_falls_back_to_full_url(self, rf):
+        """Test _get_canonical_url falls back to full_url."""
+        request = rf.get("/test/")
+
+        class MockPage:
+            full_url = "https://example.com/full/"
+
+        result = _get_canonical_url(request, MockPage())
+        assert result == "https://example.com/full/"
+
+    def test_get_robots_meta_uses_method(self):
+        """Test _get_robots_meta uses page method."""
+
+        class MockPage:
+            def get_robots_meta(self):
+                return "noindex, nofollow"
+
+        result = _get_robots_meta(MockPage())
+        assert result == "noindex, nofollow"
+
+    def test_get_robots_meta_with_none(self):
+        """Test _get_robots_meta handles None."""
+        result = _get_robots_meta(None)
+        assert result == ""
+
+    def test_make_absolute_url_already_absolute(self, rf):
+        """Test _make_absolute_url with already absolute URL."""
+        request = rf.get("/")
+        result = _make_absolute_url(request, "https://example.com/path/")
+        assert result == "https://example.com/path/"
+
+    def test_make_absolute_url_relative(self, rf):
+        """Test _make_absolute_url converts relative URL."""
+        request = rf.get("/")
+        result = _make_absolute_url(request, "/media/image.jpg")
+        assert result == "http://testserver/media/image.jpg"
+
+    def test_make_absolute_url_empty(self, rf):
+        """Test _make_absolute_url handles empty string."""
+        request = rf.get("/")
+        result = _make_absolute_url(request, "")
+        assert result == ""
+
+
+class TestOgImageData:
+    """Tests for _get_og_image_data function."""
+
+    def test_returns_empty_dict_when_no_image(self, rf):
+        """Test returns empty values when no image available."""
+        request = rf.get("/")
+        result = _get_og_image_data(request, None, None)
+
+        assert result["url"] == ""
+        assert result["alt"] == ""
+        assert result["width"] == ""
+        assert result["height"] == ""
+
+    def test_uses_page_og_image(self, rf):
+        """Test uses page og_image when available."""
+        request = rf.get("/")
+
+        class MockImage:
+            width = 1200
+            height = 630
+
+            def get_rendition(self, spec):
+                return MockRendition()
+
+        class MockRendition:
+            url = "/media/og-image.jpg"
+            width = 1200
+            height = 630
+
+        class MockPage:
+            og_image = MockImage()
+            og_image_alt = "Test alt"
+
+            def get_og_image_alt(self):
+                return "Test alt"
+
+        result = _get_og_image_data(request, MockPage(), None)
+
+        assert "/media/og-image.jpg" in result["url"]
+        assert result["alt"] == "Test alt"
+
+    def test_falls_back_to_settings_default(self, rf, site, db):
+        """Test falls back to settings default_og_image."""
+        request = rf.get("/")
+        request.site = site
+
+        class MockImage:
+            width = 1200
+            height = 630
+
+            def get_rendition(self, spec):
+                return MockRendition()
+
+        class MockRendition:
+            url = "/media/default-og.jpg"
+            width = 1200
+            height = 630
+
+        class MockPage:
+            og_image = None
+
+        # Create settings with mock image
+        settings = SEOSettings(
+            site=site,
+            default_og_image_alt="Default alt",
+        )
+        settings._default_og_image_mock = MockImage()
+
+        # Patch the image access
+        type(settings).default_og_image = property(
+            lambda self: getattr(self, "_default_og_image_mock", None)
+        )
+
+        result = _get_og_image_data(request, MockPage(), settings)
+
+        assert result["alt"] == "Default alt"


### PR DESCRIPTION
## Summary
- Implement `{% seo_head %}` template tag that outputs all SEO-related meta tags
- Basic meta tags (title, description, robots, canonical)
- Open Graph tags with image dimensions
- Twitter Card tags
- Favicon links (SVG, PNG, Apple Touch Icon)
- Site verification (Google, Bing)
- Custom head HTML injection

Closes #13

## Test Plan
- [x] All 59 tests pass
- [x] Lint checks pass (ruff)
- [x] Type checks pass (mypy)
- [ ] Manual testing in demo project