### PR TITLE
fix: use Site.find_for_request instead of request.site attribute

### DIFF
--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -11,6 +11,7 @@ from django import template
 from django.http import HttpRequest
 from django.template.loader import render_to_string
 from django.utils.safestring import SafeString, mark_safe
+from wagtail.models import Site
 
 if TYPE_CHECKING:
     from wagtail_herald.models import SEOSettings
@@ -101,7 +102,7 @@ def _build_website_schema(request: HttpRequest | None) -> dict[str, Any] | None:
     if not request:
         return None
 
-    site = getattr(request, "site", None)
+    site = Site.find_for_request(request)
     if not site:
         return None
 
@@ -199,7 +200,7 @@ def build_seo_context(
     Returns:
         Dictionary with all SEO template variables.
     """
-    site = getattr(request, "site", None) if request else None
+    site = Site.find_for_request(request) if request else None
 
     # Title with separator
     page_title = _get_page_title(page)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -535,24 +535,24 @@ class TestBuildWebsiteSchema:
         result = _build_website_schema(None)
         assert result is None
 
-    def test_returns_none_without_site(self, rf):
-        """Test returns None when no site on request."""
-        request = rf.get("/")
+    def test_returns_none_without_site(self, rf, db):
+        """Test returns None when no site matches request."""
+        # Use a hostname that doesn't match any site
+        request = rf.get("/", HTTP_HOST="unknown.example.com")
         result = _build_website_schema(request)
         assert result is None
 
     def test_returns_none_without_site_name(self, rf, site):
         """Test returns None when site has no name."""
-        request = rf.get("/")
         site.site_name = ""
-        request.site = site
+        site.save()
+        request = rf.get("/")
         result = _build_website_schema(request)
         assert result is None
 
     def test_returns_schema_with_site(self, rf, site):
         """Test returns valid schema with site."""
         request = rf.get("/")
-        request.site = site
         result = _build_website_schema(request)
 
         assert result["@context"] == "https://schema.org"


### PR DESCRIPTION
## Summary

- `request.site` 属性ではなく `Site.find_for_request(request)` を使用するように修正
- Wagtailは常に `request.site` を自動設定するとは限らないため

## 変更内容

- `_build_website_schema()` と `build_seo_context()` で `Site.find_for_request()` を使用
- 関連テストを更新（DBアクセスが必要になったため）

## 修正される問題

- タイトルにサイト名が付加されない
- `og:site_name` が出力されない

Fixes #25