### PR TITLE
perf: add select_related for SEOSettings image fields

### DIFF
--- a/src/wagtail_herald/models/settings.py
+++ b/src/wagtail_herald/models/settings.py
@@ -36,6 +36,15 @@ ORGANIZATION_TYPE_CHOICES = [
 class SEOSettings(BaseSiteSetting):
     """Site-wide SEO configuration."""
 
+    # Fetch all image ForeignKeys in a single query
+    select_related = [
+        "organization_logo",
+        "default_og_image",
+        "favicon_svg",
+        "favicon_png",
+        "apple_touch_icon",
+    ]
+
     class Meta:
         verbose_name = _("SEO Settings")
 


### PR DESCRIPTION
## Summary

- SEOSettings に `select_related` 属性を追加
- 5つの画像 ForeignKey を1クエリで取得

## 変更内容

Wagtail の `BaseSiteSetting` が提供する `select_related` サポートを活用：

```python
select_related = [
    "organization_logo",
    "default_og_image",
    "favicon_svg",
    "favicon_png",
    "apple_touch_icon",
]
```

## なぜカスタムキャッシュ不要か

- `BaseSiteSetting.for_request()` は**リクエスト単位でキャッシュ済み**
- 同一リクエスト内で `seo_head` と `seo_schema` が呼ばれても1回のクエリのみ
- Django cache framework によるTTLキャッシュは不要

## テスト

- [x] 既存テスト通過 (74 tests)
- [x] Lint / mypy 通過

Fixes #21