### PR TITLE
feat: define schema type templates

### DIFF
--- a/client/src/schema-templates.test.ts
+++ b/client/src/schema-templates.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SCHEMA_TEMPLATES,
+  getAllTypes,
+  getDefaultOnTemplates,
+  getTemplate,
+  getTemplatesByCategory,
+} from './schema-templates'
+
+describe('SCHEMA_TEMPLATES', () => {
+  it('should contain 17 schema types', () => {
+    const types = Object.keys(SCHEMA_TEMPLATES)
+    expect(types).toHaveLength(17)
+  })
+
+  it('should have all required properties for each template', () => {
+    for (const [type, template] of Object.entries(SCHEMA_TEMPLATES)) {
+      expect(template.type).toBe(type)
+      expect(template.label).toBeTruthy()
+      expect(template.labelJa).toBeTruthy()
+      expect(template.category).toBeTruthy()
+      expect(template.helpText).toBeTruthy()
+      expect(template.helpTextJa).toBeTruthy()
+      expect(Array.isArray(template.autoFields)).toBe(true)
+      expect(Array.isArray(template.requiredFields)).toBe(true)
+      expect(Array.isArray(template.optionalFields)).toBe(true)
+      expect(typeof template.placeholder).toBe('object')
+      expect(typeof template.example).toBe('object')
+      expect(template.googleDocsUrl).toBeTruthy()
+    }
+  })
+
+  it('should have valid categories', () => {
+    const validCategories = [
+      'site-wide',
+      'content',
+      'business',
+      'interactive',
+      'events',
+      'people',
+      'specialized',
+    ]
+
+    for (const template of Object.values(SCHEMA_TEMPLATES)) {
+      expect(validCategories).toContain(template.category)
+    }
+  })
+})
+
+describe('getTemplate', () => {
+  it('should return template for valid type', () => {
+    const template = getTemplate('Article')
+    expect(template).toBeDefined()
+    expect(template?.type).toBe('Article')
+    expect(template?.category).toBe('content')
+  })
+
+  it('should return undefined for invalid type', () => {
+    const template = getTemplate('InvalidType')
+    expect(template).toBeUndefined()
+  })
+})
+
+describe('getTemplatesByCategory', () => {
+  it('should group templates by category', () => {
+    const grouped = getTemplatesByCategory()
+
+    expect(grouped['site-wide']).toBeDefined()
+    expect(grouped.content).toBeDefined()
+    expect(grouped.business).toBeDefined()
+    expect(grouped.interactive).toBeDefined()
+    expect(grouped.events).toBeDefined()
+    expect(grouped.people).toBeDefined()
+    expect(grouped.specialized).toBeDefined()
+  })
+
+  it('should have correct templates in each category', () => {
+    const grouped = getTemplatesByCategory()
+
+    // site-wide: WebSite, Organization, BreadcrumbList
+    expect(grouped['site-wide']).toHaveLength(3)
+    expect(grouped['site-wide'].map((t) => t.type)).toContain('WebSite')
+    expect(grouped['site-wide'].map((t) => t.type)).toContain('Organization')
+    expect(grouped['site-wide'].map((t) => t.type)).toContain('BreadcrumbList')
+
+    // content: WebPage, Article, NewsArticle, BlogPosting
+    expect(grouped.content).toHaveLength(4)
+
+    // business: Product, LocalBusiness, Service
+    expect(grouped.business).toHaveLength(3)
+
+    // interactive: FAQPage, HowTo
+    expect(grouped.interactive).toHaveLength(2)
+
+    // events: Event
+    expect(grouped.events).toHaveLength(1)
+
+    // people: Person
+    expect(grouped.people).toHaveLength(1)
+
+    // specialized: Recipe, Course, JobPosting
+    expect(grouped.specialized).toHaveLength(3)
+  })
+})
+
+describe('getAllTypes', () => {
+  it('should return all type names', () => {
+    const types = getAllTypes()
+    expect(types).toHaveLength(17)
+    expect(types).toContain('Article')
+    expect(types).toContain('Product')
+    expect(types).toContain('FAQPage')
+    expect(types).toContain('Event')
+    expect(types).toContain('Person')
+    expect(types).toContain('Recipe')
+  })
+})
+
+describe('getDefaultOnTemplates', () => {
+  it('should return only site-wide templates with defaultOn=true', () => {
+    const defaultTemplates = getDefaultOnTemplates()
+
+    expect(defaultTemplates).toHaveLength(3)
+    expect(defaultTemplates.map((t) => t.type)).toContain('WebSite')
+    expect(defaultTemplates.map((t) => t.type)).toContain('Organization')
+    expect(defaultTemplates.map((t) => t.type)).toContain('BreadcrumbList')
+
+    for (const template of defaultTemplates) {
+      expect(template.defaultOn).toBe(true)
+      expect(template.category).toBe('site-wide')
+    }
+  })
+})
+
+describe('AutoFields', () => {
+  it('should have valid autoFields structure', () => {
+    const article = getTemplate('Article')
+    expect(article?.autoFields.length).toBeGreaterThan(0)
+
+    for (const field of article?.autoFields ?? []) {
+      expect(field.schemaProperty).toBeTruthy()
+      expect(field.source).toBeTruthy()
+      expect(field.description).toBeTruthy()
+    }
+  })
+})
+
+describe('FieldDefs', () => {
+  it('should have valid requiredFields for FAQPage', () => {
+    const faqPage = getTemplate('FAQPage')
+    expect(faqPage?.requiredFields).toHaveLength(1)
+    expect(faqPage?.requiredFields[0].name).toBe('mainEntity')
+    expect(faqPage?.requiredFields[0].type).toBe('array')
+  })
+
+  it('should have valid optionalFields for Product', () => {
+    const product = getTemplate('Product')
+    expect(product?.optionalFields.length).toBeGreaterThan(0)
+
+    const offerField = product?.optionalFields.find((f) => f.name === 'offers')
+    expect(offerField).toBeDefined()
+    expect(offerField?.type).toBe('object')
+  })
+})

--- a/client/src/schema-templates.ts
+++ b/client/src/schema-templates.ts
@@ -1,0 +1,1038 @@
+export interface SchemaTemplate {
+  type: string
+  label: string
+  labelJa: string
+  category:
+    | 'site-wide'
+    | 'content'
+    | 'business'
+    | 'interactive'
+    | 'events'
+    | 'people'
+    | 'specialized'
+  defaultOn?: boolean
+  helpText: string
+  helpTextJa: string
+  autoFields: AutoField[]
+  requiredFields: FieldDef[]
+  optionalFields: FieldDef[]
+  placeholder: Record<string, unknown>
+  example: Record<string, unknown>
+  googleDocsUrl: string
+}
+
+export interface AutoField {
+  schemaProperty: string
+  source: string
+  description: string
+}
+
+export interface FieldDef {
+  name: string
+  type: 'string' | 'number' | 'array' | 'object' | 'datetime'
+  description: string
+}
+
+export const SCHEMA_TEMPLATES: Record<string, SchemaTemplate> = {
+  // ===================
+  // Site-wide schemas (default ON)
+  // ===================
+  WebSite: {
+    type: 'WebSite',
+    label: 'WebSite',
+    labelJa: 'ウェブサイト',
+    category: 'site-wide',
+    defaultOn: true,
+    helpText: 'Site information. Auto-populated from Site settings.',
+    helpTextJa: 'サイト情報。サイト設定から自動入力されます。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'site.site_name',
+        description: 'Site name',
+      },
+      {
+        schemaProperty: 'url',
+        source: 'site.root_url',
+        description: 'Site URL',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      {
+        name: 'potentialAction',
+        type: 'object',
+        description: 'SearchAction for sitelinks search box',
+      },
+    ],
+    placeholder: {},
+    example: {
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://example.com/search?q={search_term_string}',
+      },
+    },
+    googleDocsUrl: 'https://schema.org/WebSite',
+  },
+
+  Organization: {
+    type: 'Organization',
+    label: 'Organization',
+    labelJa: '組織',
+    category: 'site-wide',
+    defaultOn: true,
+    helpText: 'Organization info. Auto-populated from SEO Settings.',
+    helpTextJa: '組織情報。SEO設定から自動入力されます。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'settings.organization_name',
+        description: 'Org name',
+      },
+      {
+        schemaProperty: 'url',
+        source: 'site.root_url',
+        description: 'Website URL',
+      },
+      {
+        schemaProperty: 'logo',
+        source: 'settings.organization_logo',
+        description: 'Logo image',
+      },
+      {
+        schemaProperty: 'sameAs',
+        source: 'settings.social_profiles',
+        description: 'Social links',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [],
+    placeholder: {},
+    example: {},
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/organization',
+  },
+
+  BreadcrumbList: {
+    type: 'BreadcrumbList',
+    label: 'BreadcrumbList',
+    labelJa: 'パンくずリスト',
+    category: 'site-wide',
+    defaultOn: true,
+    helpText:
+      'Breadcrumb navigation. Fully auto-generated from page hierarchy.',
+    helpTextJa: 'パンくずナビ。ページ階層から完全自動生成されます。',
+    autoFields: [
+      {
+        schemaProperty: 'itemListElement',
+        source: 'page.get_ancestors()',
+        description: 'Breadcrumb items',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [],
+    placeholder: {},
+    example: {},
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/breadcrumb',
+  },
+
+  // ===================
+  // Content schemas
+  // ===================
+  WebPage: {
+    type: 'WebPage',
+    label: 'Web Page',
+    labelJa: 'ウェブページ',
+    category: 'content',
+    helpText: 'Generic web page. All properties auto-generated.',
+    helpTextJa: '一般的なウェブページ。すべてのプロパティは自動生成されます。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Page title',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Meta description',
+      },
+      {
+        schemaProperty: 'url',
+        source: 'page.full_url',
+        description: 'Page URL',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [],
+    placeholder: {},
+    example: {},
+    googleDocsUrl: 'https://schema.org/WebPage',
+  },
+
+  Article: {
+    type: 'Article',
+    label: 'Article',
+    labelJa: '記事',
+    category: 'content',
+    helpText:
+      'General article. Use NewsArticle for news, BlogPosting for blogs.',
+    helpTextJa:
+      '一般的な記事。ニュースにはNewsArticle、ブログにはBlogPostingを使用。',
+    autoFields: [
+      {
+        schemaProperty: 'headline',
+        source: 'page.seo_title || page.title',
+        description: 'Article headline',
+      },
+      {
+        schemaProperty: 'author',
+        source: 'page.owner',
+        description: 'Author (Person)',
+      },
+      {
+        schemaProperty: 'datePublished',
+        source: 'page.first_published_at',
+        description: 'Publish date',
+      },
+      {
+        schemaProperty: 'dateModified',
+        source: 'page.last_published_at',
+        description: 'Last modified',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Featured image',
+      },
+      {
+        schemaProperty: 'publisher',
+        source: 'settings.organization',
+        description: 'Publisher org',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      {
+        name: 'articleSection',
+        type: 'string',
+        description: 'Article section/category',
+      },
+      { name: 'wordCount', type: 'number', description: 'Word count' },
+    ],
+    placeholder: {},
+    example: { articleSection: 'Technology', wordCount: 1500 },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/article',
+  },
+
+  NewsArticle: {
+    type: 'NewsArticle',
+    label: 'News Article',
+    labelJa: 'ニュース記事',
+    category: 'content',
+    helpText: 'News article. Enables Google News features.',
+    helpTextJa: 'ニュース記事。Googleニュース機能が有効になります。',
+    autoFields: [
+      {
+        schemaProperty: 'headline',
+        source: 'page.seo_title || page.title',
+        description: 'Article headline',
+      },
+      {
+        schemaProperty: 'author',
+        source: 'page.owner',
+        description: 'Author (Person)',
+      },
+      {
+        schemaProperty: 'datePublished',
+        source: 'page.first_published_at',
+        description: 'Publish date',
+      },
+      {
+        schemaProperty: 'dateModified',
+        source: 'page.last_published_at',
+        description: 'Last modified',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Featured image',
+      },
+      {
+        schemaProperty: 'publisher',
+        source: 'settings.organization',
+        description: 'Publisher org',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      {
+        name: 'dateline',
+        type: 'string',
+        description: 'News dateline location',
+      },
+    ],
+    placeholder: {},
+    example: { dateline: 'TOKYO' },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/article',
+  },
+
+  BlogPosting: {
+    type: 'BlogPosting',
+    label: 'Blog Post',
+    labelJa: 'ブログ記事',
+    category: 'content',
+    helpText: 'Blog post. Similar to Article but for blog content.',
+    helpTextJa: 'ブログ投稿。Articleと同様ですがブログコンテンツ向け。',
+    autoFields: [
+      {
+        schemaProperty: 'headline',
+        source: 'page.seo_title || page.title',
+        description: 'Post headline',
+      },
+      {
+        schemaProperty: 'author',
+        source: 'page.owner',
+        description: 'Author (Person)',
+      },
+      {
+        schemaProperty: 'datePublished',
+        source: 'page.first_published_at',
+        description: 'Publish date',
+      },
+      {
+        schemaProperty: 'dateModified',
+        source: 'page.last_published_at',
+        description: 'Last modified',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Featured image',
+      },
+      {
+        schemaProperty: 'publisher',
+        source: 'settings.organization',
+        description: 'Publisher org',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      { name: 'articleSection', type: 'string', description: 'Blog category' },
+      {
+        name: 'keywords',
+        type: 'string',
+        description: 'Comma-separated keywords',
+      },
+    ],
+    placeholder: {},
+    example: { articleSection: 'Tech Blog', keywords: 'wagtail, cms, python' },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/article',
+  },
+
+  // ===================
+  // Business schemas
+  // ===================
+  Product: {
+    type: 'Product',
+    label: 'Product',
+    labelJa: '商品',
+    category: 'business',
+    helpText: 'Product with price/availability. Enables rich results.',
+    helpTextJa: '価格・在庫情報付き商品ページ。リッチリザルト対応。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Product name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Product image',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      { name: 'offers', type: 'object', description: 'Price and availability' },
+      { name: 'brand', type: 'string', description: 'Brand name' },
+      { name: 'sku', type: 'string', description: 'Product SKU' },
+      { name: 'gtin', type: 'string', description: 'Global Trade Item Number' },
+    ],
+    placeholder: {
+      offers: {
+        '@type': 'Offer',
+        price: '',
+        priceCurrency: 'JPY',
+        availability: 'https://schema.org/InStock',
+      },
+    },
+    example: {
+      offers: { '@type': 'Offer', price: '1999', priceCurrency: 'JPY' },
+      brand: 'Example Brand',
+      sku: 'PROD-001',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/product',
+  },
+
+  LocalBusiness: {
+    type: 'LocalBusiness',
+    label: 'Local Business',
+    labelJa: 'ローカルビジネス',
+    category: 'business',
+    helpText: 'Local business with address and hours. Great for local SEO.',
+    helpTextJa: '住所・営業時間付きローカルビジネス。ローカルSEOに効果的。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Business name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Business image',
+      },
+    ],
+    requiredFields: [
+      { name: 'address', type: 'object', description: 'PostalAddress object' },
+    ],
+    optionalFields: [
+      { name: 'telephone', type: 'string', description: 'Phone number' },
+      {
+        name: 'openingHoursSpecification',
+        type: 'array',
+        description: 'Business hours',
+      },
+      {
+        name: 'priceRange',
+        type: 'string',
+        description: 'Price range (e.g., $$)',
+      },
+      { name: 'geo', type: 'object', description: 'GeoCoordinates' },
+    ],
+    placeholder: {
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: '',
+        addressLocality: '',
+        addressRegion: '',
+        postalCode: '',
+        addressCountry: 'JP',
+      },
+    },
+    example: {
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: '1-1-1 Shibuya',
+        addressLocality: 'Shibuya-ku',
+        addressRegion: 'Tokyo',
+        postalCode: '150-0002',
+        addressCountry: 'JP',
+      },
+      telephone: '+81-3-1234-5678',
+      priceRange: '$$',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/local-business',
+  },
+
+  Service: {
+    type: 'Service',
+    label: 'Service',
+    labelJa: 'サービス',
+    category: 'business',
+    helpText: 'Service offering. Describe what services you provide.',
+    helpTextJa: 'サービス提供。提供サービスの説明に使用。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Service name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'provider',
+        source: 'settings.organization',
+        description: 'Provider',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      { name: 'serviceType', type: 'string', description: 'Type of service' },
+      { name: 'areaServed', type: 'string', description: 'Service area' },
+      { name: 'offers', type: 'object', description: 'Service pricing' },
+    ],
+    placeholder: {},
+    example: {
+      serviceType: 'Web Development',
+      areaServed: 'Japan',
+    },
+    googleDocsUrl: 'https://schema.org/Service',
+  },
+
+  // ===================
+  // Interactive schemas
+  // ===================
+  FAQPage: {
+    type: 'FAQPage',
+    label: 'FAQ Page',
+    labelJa: 'FAQページ',
+    category: 'interactive',
+    helpText: 'FAQ with expandable Q&A. High visibility in search.',
+    helpTextJa: 'Q&A形式のFAQページ。検索結果で高い視認性。',
+    autoFields: [],
+    requiredFields: [
+      {
+        name: 'mainEntity',
+        type: 'array',
+        description: 'Array of Question objects',
+      },
+    ],
+    optionalFields: [],
+    placeholder: {
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: '',
+          acceptedAnswer: { '@type': 'Answer', text: '' },
+        },
+      ],
+    },
+    example: {
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is wagtail-herald?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'A comprehensive SEO toolkit for Wagtail CMS.',
+          },
+        },
+      ],
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/faqpage',
+  },
+
+  HowTo: {
+    type: 'HowTo',
+    label: 'How-To',
+    labelJa: 'ハウツー',
+    category: 'interactive',
+    helpText: 'Step-by-step instructions. Shows steps in search results.',
+    helpTextJa: 'ステップバイステップの手順。検索結果に手順が表示されます。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'How-to title',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Main image',
+      },
+    ],
+    requiredFields: [
+      { name: 'step', type: 'array', description: 'Array of HowToStep' },
+    ],
+    optionalFields: [
+      {
+        name: 'totalTime',
+        type: 'string',
+        description: 'ISO 8601 duration (e.g., PT30M)',
+      },
+      { name: 'estimatedCost', type: 'object', description: 'MonetaryAmount' },
+      { name: 'supply', type: 'array', description: 'Required supplies' },
+      { name: 'tool', type: 'array', description: 'Required tools' },
+    ],
+    placeholder: {
+      step: [
+        {
+          '@type': 'HowToStep',
+          name: '',
+          text: '',
+        },
+      ],
+    },
+    example: {
+      step: [
+        {
+          '@type': 'HowToStep',
+          name: 'Install',
+          text: 'pip install wagtail-herald',
+        },
+        {
+          '@type': 'HowToStep',
+          name: 'Configure',
+          text: 'Add to INSTALLED_APPS',
+        },
+      ],
+      totalTime: 'PT10M',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/how-to',
+  },
+
+  // ===================
+  // Events schema
+  // ===================
+  Event: {
+    type: 'Event',
+    label: 'Event',
+    labelJa: 'イベント',
+    category: 'events',
+    helpText: 'Event with date, location, and tickets. Shows in Google Events.',
+    helpTextJa: '日時・場所・チケット情報付きイベント。Googleイベントに表示。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Event name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Event image',
+      },
+    ],
+    requiredFields: [
+      {
+        name: 'startDate',
+        type: 'datetime',
+        description: 'Event start date/time',
+      },
+      {
+        name: 'location',
+        type: 'object',
+        description: 'Place or VirtualLocation',
+      },
+    ],
+    optionalFields: [
+      { name: 'endDate', type: 'datetime', description: 'Event end date/time' },
+      {
+        name: 'eventStatus',
+        type: 'string',
+        description: 'EventScheduled, EventCancelled, etc.',
+      },
+      {
+        name: 'eventAttendanceMode',
+        type: 'string',
+        description: 'Online, Offline, Mixed',
+      },
+      { name: 'offers', type: 'object', description: 'Ticket information' },
+      {
+        name: 'performer',
+        type: 'object',
+        description: 'Person or Organization',
+      },
+      {
+        name: 'organizer',
+        type: 'object',
+        description: 'Person or Organization',
+      },
+    ],
+    placeholder: {
+      startDate: '',
+      location: {
+        '@type': 'Place',
+        name: '',
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: '',
+          addressLocality: '',
+          addressCountry: 'JP',
+        },
+      },
+    },
+    example: {
+      startDate: '2025-03-15T19:00:00+09:00',
+      endDate: '2025-03-15T21:00:00+09:00',
+      location: {
+        '@type': 'Place',
+        name: 'Tokyo International Forum',
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: '3-5-1 Marunouchi',
+          addressLocality: 'Chiyoda-ku',
+          addressCountry: 'JP',
+        },
+      },
+      eventStatus: 'https://schema.org/EventScheduled',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/event',
+  },
+
+  // ===================
+  // People schema
+  // ===================
+  Person: {
+    type: 'Person',
+    label: 'Person',
+    labelJa: '人物',
+    category: 'people',
+    helpText: 'Person profile. Useful for author pages and team members.',
+    helpTextJa: '人物プロフィール。著者ページやチームメンバーに有用。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Person name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Bio',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Photo',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      { name: 'jobTitle', type: 'string', description: 'Job title' },
+      { name: 'worksFor', type: 'object', description: 'Organization' },
+      { name: 'email', type: 'string', description: 'Email address' },
+      { name: 'sameAs', type: 'array', description: 'Social profile URLs' },
+      {
+        name: 'alumniOf',
+        type: 'object',
+        description: 'Educational organization',
+      },
+    ],
+    placeholder: {},
+    example: {
+      jobTitle: 'Software Engineer',
+      worksFor: { '@type': 'Organization', name: 'Example Corp' },
+      sameAs: ['https://twitter.com/example', 'https://github.com/example'],
+    },
+    googleDocsUrl: 'https://schema.org/Person',
+  },
+
+  // ===================
+  // Specialized schemas
+  // ===================
+  Recipe: {
+    type: 'Recipe',
+    label: 'Recipe',
+    labelJa: 'レシピ',
+    category: 'specialized',
+    helpText:
+      'Recipe with ingredients and steps. Shows rich results with image.',
+    helpTextJa: '材料・手順付きレシピ。画像付きリッチリザルトに表示。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Recipe name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'image',
+        source: 'page.og_image',
+        description: 'Recipe image',
+      },
+      {
+        schemaProperty: 'author',
+        source: 'page.owner',
+        description: 'Recipe author',
+      },
+      {
+        schemaProperty: 'datePublished',
+        source: 'page.first_published_at',
+        description: 'Publish date',
+      },
+    ],
+    requiredFields: [
+      {
+        name: 'recipeIngredient',
+        type: 'array',
+        description: 'List of ingredients',
+      },
+      {
+        name: 'recipeInstructions',
+        type: 'array',
+        description: 'Cooking steps',
+      },
+    ],
+    optionalFields: [
+      { name: 'prepTime', type: 'string', description: 'ISO 8601 duration' },
+      { name: 'cookTime', type: 'string', description: 'ISO 8601 duration' },
+      { name: 'totalTime', type: 'string', description: 'ISO 8601 duration' },
+      {
+        name: 'recipeYield',
+        type: 'string',
+        description: 'Number of servings',
+      },
+      {
+        name: 'recipeCategory',
+        type: 'string',
+        description: 'Meal type (e.g., Dinner)',
+      },
+      {
+        name: 'recipeCuisine',
+        type: 'string',
+        description: 'Cuisine type (e.g., Japanese)',
+      },
+      {
+        name: 'nutrition',
+        type: 'object',
+        description: 'NutritionInformation',
+      },
+    ],
+    placeholder: {
+      recipeIngredient: [],
+      recipeInstructions: [{ '@type': 'HowToStep', text: '' }],
+    },
+    example: {
+      recipeIngredient: ['2 cups flour', '1 cup sugar', '2 eggs'],
+      recipeInstructions: [
+        { '@type': 'HowToStep', text: 'Mix dry ingredients' },
+        { '@type': 'HowToStep', text: 'Add wet ingredients' },
+        { '@type': 'HowToStep', text: 'Bake at 350°F for 30 minutes' },
+      ],
+      prepTime: 'PT15M',
+      cookTime: 'PT30M',
+      recipeYield: '8 servings',
+      recipeCuisine: 'American',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/recipe',
+  },
+
+  Course: {
+    type: 'Course',
+    label: 'Course',
+    labelJa: 'コース',
+    category: 'specialized',
+    helpText: 'Educational course. Shows in Google course listings.',
+    helpTextJa: '教育コース。Googleコース一覧に表示。',
+    autoFields: [
+      {
+        schemaProperty: 'name',
+        source: 'page.title',
+        description: 'Course name',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Description',
+      },
+      {
+        schemaProperty: 'provider',
+        source: 'settings.organization',
+        description: 'Provider',
+      },
+    ],
+    requiredFields: [],
+    optionalFields: [
+      { name: 'courseCode', type: 'string', description: 'Course code/ID' },
+      {
+        name: 'hasCourseInstance',
+        type: 'array',
+        description: 'Course instances with dates',
+      },
+      {
+        name: 'educationalLevel',
+        type: 'string',
+        description: 'Difficulty level',
+      },
+      { name: 'offers', type: 'object', description: 'Pricing information' },
+      {
+        name: 'totalHistoricalEnrollment',
+        type: 'number',
+        description: 'Total enrollments',
+      },
+    ],
+    placeholder: {},
+    example: {
+      courseCode: 'CS101',
+      educationalLevel: 'Beginner',
+      hasCourseInstance: [
+        {
+          '@type': 'CourseInstance',
+          courseMode: 'Online',
+          startDate: '2025-04-01',
+        },
+      ],
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/course',
+  },
+
+  JobPosting: {
+    type: 'JobPosting',
+    label: 'Job Posting',
+    labelJa: '求人情報',
+    category: 'specialized',
+    helpText: 'Job listing. Shows in Google Jobs search.',
+    helpTextJa: '求人情報。Google求人検索に表示。',
+    autoFields: [
+      {
+        schemaProperty: 'title',
+        source: 'page.title',
+        description: 'Job title',
+      },
+      {
+        schemaProperty: 'description',
+        source: 'page.search_description',
+        description: 'Job description',
+      },
+      {
+        schemaProperty: 'datePosted',
+        source: 'page.first_published_at',
+        description: 'Post date',
+      },
+      {
+        schemaProperty: 'hiringOrganization',
+        source: 'settings.organization',
+        description: 'Employer',
+      },
+    ],
+    requiredFields: [
+      {
+        name: 'jobLocation',
+        type: 'object',
+        description: 'Place with address',
+      },
+    ],
+    optionalFields: [
+      {
+        name: 'validThrough',
+        type: 'datetime',
+        description: 'Application deadline',
+      },
+      {
+        name: 'employmentType',
+        type: 'string',
+        description: 'FULL_TIME, PART_TIME, etc.',
+      },
+      { name: 'baseSalary', type: 'object', description: 'MonetaryAmount' },
+      {
+        name: 'jobLocationType',
+        type: 'string',
+        description: 'TELECOMMUTE for remote',
+      },
+      {
+        name: 'applicantLocationRequirements',
+        type: 'object',
+        description: 'Location requirements',
+      },
+    ],
+    placeholder: {
+      jobLocation: {
+        '@type': 'Place',
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: '',
+          addressLocality: '',
+          addressRegion: '',
+          postalCode: '',
+          addressCountry: 'JP',
+        },
+      },
+    },
+    example: {
+      jobLocation: {
+        '@type': 'Place',
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: '1-1-1 Shibuya',
+          addressLocality: 'Shibuya-ku',
+          addressRegion: 'Tokyo',
+          postalCode: '150-0002',
+          addressCountry: 'JP',
+        },
+      },
+      employmentType: 'FULL_TIME',
+      baseSalary: {
+        '@type': 'MonetaryAmount',
+        currency: 'JPY',
+        value: {
+          '@type': 'QuantitativeValue',
+          minValue: 5000000,
+          maxValue: 8000000,
+          unitText: 'YEAR',
+        },
+      },
+      validThrough: '2025-06-30T23:59:59+09:00',
+    },
+    googleDocsUrl:
+      'https://developers.google.com/search/docs/appearance/structured-data/job-posting',
+  },
+}
+
+/**
+ * Get templates grouped by category
+ */
+export function getTemplatesByCategory(): Record<string, SchemaTemplate[]> {
+  const categories: Record<string, SchemaTemplate[]> = {}
+
+  for (const template of Object.values(SCHEMA_TEMPLATES)) {
+    if (!categories[template.category]) {
+      categories[template.category] = []
+    }
+    categories[template.category].push(template)
+  }
+
+  return categories
+}
+
+/**
+ * Get a single template by type
+ */
+export function getTemplate(type: string): SchemaTemplate | undefined {
+  return SCHEMA_TEMPLATES[type]
+}
+
+/**
+ * Get all template types
+ */
+export function getAllTypes(): string[] {
+  return Object.keys(SCHEMA_TEMPLATES)
+}
+
+/**
+ * Get templates that are default on (site-wide)
+ */
+export function getDefaultOnTemplates(): SchemaTemplate[] {
+  return Object.values(SCHEMA_TEMPLATES).filter((t) => t.defaultOn === true)
+}


### PR DESCRIPTION
## Summary

Define TypeScript templates for all 17 schema types with help text, placeholders, examples, and auto-field mappings.

## Schema Types (17 total)

| Category | Types |
|----------|-------|
| site-wide (3) | WebSite, Organization, BreadcrumbList |
| content (4) | WebPage, Article, NewsArticle, BlogPosting |
| business (3) | Product, LocalBusiness, Service |
| interactive (2) | FAQPage, HowTo |
| events (1) | Event |
| people (1) | Person |
| specialized (3) | Recipe, Course, JobPosting |

## Files Added

- `client/src/schema-templates.ts` - Template definitions
- `client/src/schema-templates.test.ts` - Unit tests (12 tests)

## Helper Functions

- `getTemplatesByCategory()` - Group templates by category
- `getTemplate(type)` - Get single template by type
- `getAllTypes()` - Get all type names
- `getDefaultOnTemplates()` - Get site-wide default templates

## Test plan

- [x] All 17 schema types defined
- [x] Each has: label, labelJa, helpText, helpTextJa
- [x] Each has: autoFields, requiredFields, optionalFields
- [x] Each has: placeholder, example, googleDocsUrl
- [x] Category grouping works
- [x] TypeScript compiles without errors
- [x] Unit tests pass (12 tests)
- [x] CI passes

Closes #50