### PR TITLE
feat: add inLanguage to Schema.org output

### DIFF
--- a/src/wagtail_herald/models/mixins.py
+++ b/src/wagtail_herald/models/mixins.py
@@ -199,3 +199,23 @@ class SEOPageMixin(models.Model):
         """
         locale = self.get_page_locale()
         return locale.replace("_", "-")
+
+    def get_schema_language(self) -> str:
+        """Return BCP 47 language code for Schema.org inLanguage property.
+
+        Uses script subtags for Chinese (zh-Hans, zh-Hant) as recommended
+        by W3C, since the difference is script-based rather than regional.
+
+        Returns:
+            The language code string in BCP 47 format.
+        """
+        locale = self.get_page_locale()
+
+        # Chinese requires script subtags (W3C recommendation)
+        if locale == "zh_CN":
+            return "zh-Hans"
+        elif locale == "zh_TW":
+            return "zh-Hant"
+
+        # Other locales: use simple language code
+        return locale.split("_")[0].lower()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -207,6 +207,7 @@ class TestSEOPageMixinMethods:
             get_page_locale = SEOPageMixin.get_page_locale
             get_page_lang = SEOPageMixin.get_page_lang
             get_html_lang = SEOPageMixin.get_html_lang
+            get_schema_language = SEOPageMixin.get_schema_language
 
         return MockPage()
 
@@ -358,3 +359,38 @@ class TestSEOPageMixinMethods:
         # Should fall back to default without raising
         result = mixin_instance.get_page_locale()
         assert result == "en_US"
+
+    def test_get_schema_language_default(self, mixin_instance):
+        """Test get_schema_language returns 'en' by default."""
+        result = mixin_instance.get_schema_language()
+        assert result == "en"
+
+    def test_get_schema_language_japanese(self, mixin_instance):
+        """Test get_schema_language returns 'ja' for Japanese locale."""
+        mixin_instance.locale = "ja_JP"
+        result = mixin_instance.get_schema_language()
+        assert result == "ja"
+
+    def test_get_schema_language_simplified_chinese(self, mixin_instance):
+        """Test get_schema_language returns 'zh-Hans' for Simplified Chinese."""
+        mixin_instance.locale = "zh_CN"
+        result = mixin_instance.get_schema_language()
+        assert result == "zh-Hans"
+
+    def test_get_schema_language_traditional_chinese(self, mixin_instance):
+        """Test get_schema_language returns 'zh-Hant' for Traditional Chinese."""
+        mixin_instance.locale = "zh_TW"
+        result = mixin_instance.get_schema_language()
+        assert result == "zh-Hant"
+
+    def test_get_schema_language_german(self, mixin_instance):
+        """Test get_schema_language returns 'de' for German locale."""
+        mixin_instance.locale = "de_DE"
+        result = mixin_instance.get_schema_language()
+        assert result == "de"
+
+    def test_get_schema_language_korean(self, mixin_instance):
+        """Test get_schema_language returns 'ko' for Korean locale."""
+        mixin_instance.locale = "ko_KR"
+        result = mixin_instance.get_schema_language()
+        assert result == "ko"


### PR DESCRIPTION
## Related Issue
Closes #64

## Summary

Add `inLanguage` property to Schema.org structured data output for all applicable schema types.

## Changes

### SEOPageMixin
- Add `get_schema_language()` method that returns BCP 47 language code
- Uses script subtags for Chinese: `zh_CN` → `zh-Hans`, `zh_TW` → `zh-Hant`
- Falls back to simple language code for other locales (e.g., `ja`, `en`, `ko`)

### Template Tags
- Add `_get_schema_language()` helper function with fallback chain:
  1. Page's `get_schema_language()` method (SEOPageMixin)
  2. SEOSettings `default_locale`
  3. Default to `"en"`
- Modify `_build_schema_for_type()` to include `inLanguage` property
- **Person type excluded** as it uses `knowsLanguage` instead of `inLanguage` per Schema.org spec

### Output Example

```json
{
  "@context": "https://schema.org",
  "@type": "Article",
  "inLanguage": "ja",
  "name": "記事タイトル",
  ...
}
```

### Supported Schema Types
- Article, NewsArticle, BlogPosting
- WebPage, FAQPage
- Event, Course, Recipe, HowTo, JobPosting
- Product, Service
- ⚠️ Person (excluded - uses `knowsLanguage` instead)

## Tests
- [x] 250 tests passing
- [x] Type check (mypy) passing
- [x] Lint (ruff) passing

## References
- [Schema.org inLanguage](https://schema.org/inLanguage)
- [W3C BCP 47 Guide](https://www.w3.org/International/articles/bcp47/)

---
Draft PR - Awaiting CI verification