### PR TITLE
Release v0.4.1

### DIFF
--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -46,6 +46,70 @@ def get_seo_settings(request: HttpRequest | None) -> SEOSettings | None:
     return result
 
 
+def _get_page_locale_cached(page: Any, settings: SEOSettings | None) -> str:
+    """Get page locale using cached settings.
+
+    Avoids database query by using pre-cached SEOSettings instead of
+    calling page.get_page_locale() which would query SEOSettings.for_site().
+
+    Args:
+        page: Wagtail page instance.
+        settings: Pre-cached SEOSettings instance.
+
+    Returns:
+        Locale string in og:locale format (e.g., 'ja_JP', 'en_US').
+    """
+    # Check page's seo_locale first (SEOPageMixin field)
+    if page and hasattr(page, "seo_locale") and page.seo_locale:
+        return str(page.seo_locale)
+
+    # Fall back to settings default_locale
+    if settings and settings.default_locale:
+        return str(settings.default_locale)
+
+    return "en_US"
+
+
+def _get_page_lang_cached(page: Any, settings: SEOSettings | None) -> str:
+    """Get page language code using cached settings.
+
+    Avoids database query by using pre-cached SEOSettings.
+
+    Args:
+        page: Wagtail page instance.
+        settings: Pre-cached SEOSettings instance.
+
+    Returns:
+        Language code string (e.g., 'ja', 'en', 'zh').
+    """
+    locale = _get_page_locale_cached(page, settings)
+    return locale.split("_")[0].lower()
+
+
+def _get_schema_language_cached(page: Any, settings: SEOSettings | None) -> str:
+    """Get BCP 47 language code for Schema.org using cached settings.
+
+    Avoids database query by using pre-cached SEOSettings.
+
+    Args:
+        page: Wagtail page instance.
+        settings: Pre-cached SEOSettings instance.
+
+    Returns:
+        BCP 47 language code string (e.g., 'ja', 'en', 'zh-Hans').
+    """
+    locale = _get_page_locale_cached(page, settings)
+
+    # Chinese requires script subtags (W3C recommendation)
+    if locale == "zh_CN":
+        return "zh-Hans"
+    elif locale == "zh_TW":
+        return "zh-Hant"
+
+    # Other locales: use simple language code
+    return locale.split("_")[0].lower()
+
+
 @register.simple_tag(takes_context=True)
 def seo_head(context: dict[str, Any]) -> SafeString:
     """Output all SEO meta tags, OG tags, Twitter Card, favicons, and custom HTML.
@@ -179,18 +243,11 @@ def page_lang(context: dict[str, Any]) -> str:
     3. 'en'
     """
     page = context.get("page") or context.get("self")
-
-    # Try to get from page's method
-    if page and hasattr(page, "get_page_lang"):
-        return str(page.get_page_lang())
-
-    # Fallback: try to get from SEOSettings
     request = context.get("request")
     settings = get_seo_settings(request)
-    if settings and settings.default_locale:
-        return str(settings.default_locale).split("_")[0].lower()
 
-    return "en"
+    # Use cached helper to avoid duplicate database queries
+    return _get_page_lang_cached(page, settings)
 
 
 @register.simple_tag(takes_context=True)
@@ -207,18 +264,11 @@ def page_locale(context: dict[str, Any]) -> str:
     3. 'en_US'
     """
     page = context.get("page") or context.get("self")
-
-    # Try to get from page's method
-    if page and hasattr(page, "get_page_locale"):
-        return str(page.get_page_locale())
-
-    # Fallback: try to get from SEOSettings
     request = context.get("request")
     settings = get_seo_settings(request)
-    if settings and settings.default_locale:
-        return str(settings.default_locale)
 
-    return "en_US"
+    # Use cached helper to avoid duplicate database queries
+    return _get_page_locale_cached(page, settings)
 
 
 def _build_website_schema(request: HttpRequest | None) -> dict[str, Any] | None:
@@ -670,11 +720,8 @@ def build_seo_context(
     og_image_data = _get_og_image_data(request, page, settings)
 
     # Locale (page-specific takes priority over settings default)
-    locale = "en_US"
-    if page and hasattr(page, "get_page_locale"):
-        locale = page.get_page_locale()
-    elif settings and settings.default_locale:
-        locale = settings.default_locale
+    # Use cached helper to avoid duplicate database queries
+    locale = _get_page_locale_cached(page, settings)
 
     # Favicon URLs
     favicon_svg_url = _get_image_url(request, settings.favicon_svg) if settings else ""
@@ -774,8 +821,8 @@ def _get_robots_meta(page: Any) -> str:
 def _get_schema_language(page: Any, settings: Any) -> str:
     """Get BCP 47 language code for Schema.org inLanguage property.
 
-    Uses page's get_schema_language method if available (SEOPageMixin),
-    otherwise falls back to settings.default_locale or 'en'.
+    Uses cached helper to avoid duplicate database queries from
+    page.get_schema_language() which would call SEOSettings.for_site().
 
     Args:
         page: Wagtail page instance.
@@ -784,21 +831,8 @@ def _get_schema_language(page: Any, settings: Any) -> str:
     Returns:
         BCP 47 language code string (e.g., 'ja', 'en', 'zh-Hans').
     """
-    # Try page's method first (SEOPageMixin)
-    if page and hasattr(page, "get_schema_language"):
-        return str(page.get_schema_language())
-
-    # Fall back to settings default_locale
-    if settings and hasattr(settings, "default_locale") and settings.default_locale:
-        locale = str(settings.default_locale)
-        # Chinese requires script subtags
-        if locale == "zh_CN":
-            return "zh-Hans"
-        elif locale == "zh_TW":
-            return "zh-Hant"
-        return locale.split("_")[0].lower()
-
-    return "en"
+    # Use cached helper to avoid duplicate database queries
+    return _get_schema_language_cached(page, settings)
 
 
 def _get_og_image_data(

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1879,11 +1879,10 @@ class TestPageLangTemplateTag:
     """Tests for page_lang template tag."""
 
     def test_page_lang_with_seo_mixin(self, rf, db):
-        """Test page_lang returns language from page with SEOPageMixin."""
+        """Test page_lang returns language from page with seo_locale field."""
 
         class MockPage:
-            def get_page_lang(self):
-                return "ja"
+            seo_locale = "ja_JP"
 
         request = rf.get("/")
         context = {"request": request, "page": MockPage()}
@@ -1921,11 +1920,10 @@ class TestPageLocaleTemplateTag:
     """Tests for page_locale template tag."""
 
     def test_page_locale_with_seo_mixin(self, rf, db):
-        """Test page_locale returns full locale from page with SEOPageMixin."""
+        """Test page_locale returns full locale from page with seo_locale field."""
 
         class MockPage:
-            def get_page_locale(self):
-                return "ja_JP"
+            seo_locale = "ja_JP"
 
         request = rf.get("/")
         context = {"request": request, "page": MockPage()}
@@ -1963,16 +1961,14 @@ class TestBuildSeoContextLocale:
     """Tests for build_seo_context locale handling."""
 
     def test_og_locale_from_page(self, rf, db):
-        """Test og_locale uses page locale when available."""
+        """Test og_locale uses page seo_locale field when available."""
         from wagtail_herald.templatetags.wagtail_herald import build_seo_context
 
         class MockPage:
             title = "Test Page"
             search_description = ""
             full_url = "https://example.com/test/"
-
-            def get_page_locale(self):
-                return "ko_KR"
+            seo_locale = "ko_KR"
 
             def get_canonical_url(self, request=None):
                 return self.full_url
@@ -2025,14 +2021,12 @@ class TestSchemaInLanguage:
     """Tests for inLanguage property in Schema.org output."""
 
     def test_inlanguage_with_page_locale(self, rf):
-        """Test inLanguage uses page's get_schema_language method."""
+        """Test inLanguage uses page's seo_locale field."""
 
         class MockPage:
             title = "Test Article"
             full_url = "https://example.com/article/"
-
-            def get_schema_language(self):
-                return "ja"
+            seo_locale = "ja_JP"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Article", {})
 
@@ -2044,9 +2038,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "Test Article"
             full_url = "https://example.com/article/"
-
-            def get_schema_language(self):
-                return "zh-Hans"
+            seo_locale = "zh_CN"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Article", {})
 
@@ -2058,9 +2050,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "Test Article"
             full_url = "https://example.com/article/"
-
-            def get_schema_language(self):
-                return "zh-Hant"
+            seo_locale = "zh_TW"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Article", {})
 
@@ -2099,9 +2089,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "John Doe"
             full_url = "https://example.com/person/"
-
-            def get_schema_language(self):
-                return "ja"
+            seo_locale = "ja_JP"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Person", {})
 
@@ -2113,9 +2101,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "My Blog Post"
             full_url = "https://example.com/blog/post/"
-
-            def get_schema_language(self):
-                return "de"
+            seo_locale = "de_DE"
 
         result = _build_schema_for_type(
             rf.get("/"), MockPage(), None, "BlogPosting", {}
@@ -2129,9 +2115,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "News Article"
             full_url = "https://example.com/news/article/"
-
-            def get_schema_language(self):
-                return "ko"
+            seo_locale = "ko_KR"
 
         result = _build_schema_for_type(
             rf.get("/"), MockPage(), None, "NewsArticle", {}
@@ -2145,9 +2129,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "Conference 2024"
             full_url = "https://example.com/events/conference/"
-
-            def get_schema_language(self):
-                return "es"
+            seo_locale = "es_ES"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Event", {})
 
@@ -2159,9 +2141,7 @@ class TestSchemaInLanguage:
         class MockPage:
             title = "Super Widget"
             full_url = "https://example.com/products/widget/"
-
-            def get_schema_language(self):
-                return "pt"
+            seo_locale = "pt_BR"
 
         result = _build_schema_for_type(rf.get("/"), MockPage(), None, "Product", {})
 
@@ -2350,13 +2330,12 @@ class TestGtmInSeoHead:
 class TestGetSchemaLanguageHelper:
     """Tests for _get_schema_language helper function."""
 
-    def test_uses_page_method(self, rf):
-        """Test helper uses page's get_schema_language method."""
+    def test_uses_page_seo_locale(self, rf):
+        """Test helper uses page's seo_locale field."""
         from wagtail_herald.templatetags.wagtail_herald import _get_schema_language
 
         class MockPage:
-            def get_schema_language(self):
-                return "ja"
+            seo_locale = "ja_JP"
 
         result = _get_schema_language(MockPage(), None)
         assert result == "ja"


### PR DESCRIPTION
## Summary

- fix: properly cache SEOSettings to avoid duplicate queries (#90)

The previous caching fix was incomplete. The mixin methods (get_page_locale, get_page_lang, get_schema_language) were calling SEOSettings.for_site() directly, bypassing the request-level cache.

This release adds cached helper functions and updates template tags to use them, reducing SEOSettings queries from 3 to 1 per request.

## Changes

- Added `_get_page_locale_cached`, `_get_page_lang_cached`, `_get_schema_language_cached` helper functions
- Updated `page_lang`, `page_locale` template tags to use cached helpers
- Updated `build_seo_context` and `_get_schema_language` to use cached helpers
- Updated tests to reflect the new caching approach