### PR TITLE
docs: add PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # wagtail-herald
 
 [![PyPI version](https://badge.fury.io/py/wagtail-herald.svg)](https://badge.fury.io/py/wagtail-herald)
+[![Downloads](https://static.pepy.tech/badge/wagtail-herald)](https://pepy.tech/project/wagtail-herald)
 [![CI](https://github.com/kkm-horikawa/wagtail-herald/actions/workflows/ci.yml/badge.svg)](https://github.com/kkm-horikawa/wagtail-herald/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/kkm-horikawa/wagtail-herald/graph/badge.svg)](https://codecov.io/gh/kkm-horikawa/wagtail-herald)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)


### PR DESCRIPTION
Add pepy.tech downloads badge to show total PyPI downloads in README.