### PR TITLE
feat: ファビコンを恒久ルートパスで配信し検索結果の地球儀化を防ぐ

### DIFF
--- a/src/wagtail_herald/templates/wagtail_herald/seo_head.html
+++ b/src/wagtail_herald/templates/wagtail_herald/seo_head.html
@@ -36,10 +36,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% if twitter_image %}<meta name="twitter:image" content="{{ twitter_image }}">{% endif %}
 {% if twitter_image_alt %}<meta name="twitter:image:alt" content="{{ twitter_image_alt }}">{% endif %}
 
-{# Favicon #}
-{% if favicon_svg %}<link rel="icon" type="image/svg+xml" href="{{ favicon_svg }}">{% endif %}
-{% if favicon_png %}<link rel="icon" type="image/png" sizes="48x48" href="{{ favicon_png }}">{% endif %}
-{% if apple_touch_icon %}<link rel="apple-touch-icon" sizes="180x180" href="{{ apple_touch_icon }}">{% endif %}
+{# Favicon — wagtail_herald.urls が恒久ルートパスで長期キャッシュ配信する。
+   CMS メディア URL（再アップロードで変わる）に依存させないことで地球儀化を防ぐ #}
+{% if favicon_svg %}<link rel="icon" type="image/svg+xml" href="/favicon.svg">{% endif %}
+{% if favicon_png %}<link rel="icon" type="image/png"{% if favicon_png_sizes %} sizes="{{ favicon_png_sizes }}"{% endif %} href="/favicon.ico">{% endif %}
+{% if apple_touch_icon %}<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">{% endif %}
 
 {# Custom Head HTML - output raw, no escaping #}
 {% if custom_head_html %}{{ custom_head_html|safe }}{% endif %}

--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -870,6 +870,13 @@ def build_seo_context(
     apple_touch_icon_url = (
         _get_image_url(request, settings.apple_touch_icon) if settings else ""
     )
+    # PNG ファビコンの実寸（sizes 属性用）。固定の 48x48 ではなく実際の画像サイズを使う
+    favicon_png_image = settings.favicon_png if settings else None
+    favicon_png_sizes = (
+        f"{favicon_png_image.width}x{favicon_png_image.height}"
+        if favicon_png_image
+        else ""
+    )
 
     return {
         "title": page_title,
@@ -894,6 +901,7 @@ def build_seo_context(
         "twitter_image_alt": og_image_data.get("alt"),
         "favicon_svg": favicon_svg_url,
         "favicon_png": favicon_png_url,
+        "favicon_png_sizes": favicon_png_sizes,
         "apple_touch_icon": apple_touch_icon_url,
         "gtm_container_id": ""
         if _should_exclude_gtm(request)

--- a/src/wagtail_herald/urls.py
+++ b/src/wagtail_herald/urls.py
@@ -12,12 +12,24 @@ Usage in your project's urls.py:
 
 from django.urls import path, re_path
 
-from wagtail_herald.views import ads_txt, indexnow_key_file, robots_txt, security_txt
+from wagtail_herald.views import (
+    ads_txt,
+    apple_touch_icon,
+    favicon,
+    favicon_svg,
+    indexnow_key_file,
+    robots_txt,
+    security_txt,
+)
 
 urlpatterns = [
     path("robots.txt", robots_txt, name="robots_txt"),
     path("ads.txt", ads_txt, name="ads_txt"),
     path(".well-known/security.txt", security_txt, name="security_txt"),
+    # ファビコンを恒久ルートパスで配信（地球儀化対策）
+    path("favicon.ico", favicon, name="favicon"),
+    path("favicon.svg", favicon_svg, name="favicon_svg"),
+    path("apple-touch-icon.png", apple_touch_icon, name="apple_touch_icon"),
     re_path(
         r"^(?P<key>[a-zA-Z0-9\-]{8,128})\.txt$",
         indexnow_key_file,

--- a/src/wagtail_herald/views.py
+++ b/src/wagtail_herald/views.py
@@ -2,10 +2,15 @@
 Views for wagtail-herald.
 """
 
-from django.http import Http404, HttpRequest, HttpResponse
+import mimetypes
+
+from django.http import FileResponse, Http404, HttpRequest, HttpResponse
 from wagtail.models import Site
 
 from wagtail_herald.models import SEOSettings
+
+# ファビコンは中身が変わらないため 1 年・immutable でキャッシュさせる
+FAVICON_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 
 def get_default_robots_txt(request: HttpRequest) -> str:
@@ -161,3 +166,60 @@ def indexnow_key_file(request: HttpRequest, key: str) -> HttpResponse:
             return HttpResponse(key, content_type="text/plain")
 
     raise Http404
+
+
+def _serve_favicon(
+    request: HttpRequest, field_name: str, default_content_type: str
+) -> FileResponse:
+    """Serve a configured favicon image from a stable root path.
+
+    Google のファビコン取得は ``/favicon.ico`` などのルートを必ず探し、リトライにも
+    寛容ではない。404 や取得失敗が一度でもあると検索結果のファビコンが地球儀に戻る。
+    そこで設定済みのファビコン画像を恒久ルートパスで・長期キャッシュ付きで返す。
+
+    CMS のメディア URL（再アップロードで変わる・エッジから消えやすい）に依存させず、
+    この herald 所有の URL を不変の入口にすることで地球儀化を防ぐ。
+
+    Args:
+        request: The HTTP request object.
+        field_name: SEOSettings の画像フィールド名（favicon_png など）。
+        default_content_type: 拡張子から判定できなかった場合の Content-Type。
+
+    Returns:
+        FileResponse with a long-lived Cache-Control header.
+
+    Raises:
+        Http404: If no image is configured for the current site.
+    """
+    site = Site.find_for_request(request)
+
+    if site:
+        seo_settings = SEOSettings.for_request(request)
+        image = getattr(seo_settings, field_name, None) if seo_settings else None
+        if image:
+            content_type = (
+                mimetypes.guess_type(image.file.name)[0] or default_content_type
+            )
+            response = FileResponse(image.file.open("rb"), content_type=content_type)
+            response["Cache-Control"] = FAVICON_CACHE_CONTROL
+            return response
+
+    raise Http404
+
+
+def favicon(request: HttpRequest) -> FileResponse:
+    """Serve ``/favicon.ico`` from the configured PNG favicon.
+
+    ブラウザと Google が暗黙に叩くルート。設定の ``favicon_png`` を返す。
+    """
+    return _serve_favicon(request, "favicon_png", "image/png")
+
+
+def favicon_svg(request: HttpRequest) -> FileResponse:
+    """Serve ``/favicon.svg`` from the configured SVG favicon."""
+    return _serve_favicon(request, "favicon_svg", "image/svg+xml")
+
+
+def apple_touch_icon(request: HttpRequest) -> FileResponse:
+    """Serve ``/apple-touch-icon.png`` from the configured Apple touch icon."""
+    return _serve_favicon(request, "apple_touch_icon", "image/png")

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -1,0 +1,121 @@
+"""Integration tests for the root favicon endpoints.
+
+Google のファビコン取得は ``/favicon.ico`` などのルートを必ず探し、取得失敗が
+一度でもあると検索結果のファビコンが地球儀に戻る。herald が設定済みのファビコン
+画像を恒久ルートパスで・長期キャッシュ付きで返すことを保証する。
+
+| ID  | パス                  | 設定         | 期待結果                              |
+|-----|-----------------------|--------------|---------------------------------------|
+| FV1 | /favicon.ico          | favicon_png  | 200 / image/png / 1年 immutable cache |
+| FV2 | /favicon.ico          | なし         | 404                                   |
+| FV3 | /favicon.svg          | favicon_svg  | 200 / 1年 immutable cache             |
+| FV4 | /apple-touch-icon.png | apple_touch  | 200 / 1年 immutable cache             |
+"""
+
+import pytest
+from django.test import Client
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
+from wagtail.models import Page, Site
+
+from wagtail_herald.models import SEOSettings
+
+ONE_YEAR_IMMUTABLE = "public, max-age=31536000, immutable"
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def root_page(db):
+    try:
+        return Page.objects.get(depth=1)
+    except Page.DoesNotExist:
+        return Page.add_root(title="Root", slug="root")
+
+
+@pytest.fixture
+def default_site(db, root_page):
+    site, _created = Site.objects.get_or_create(
+        hostname="localhost",
+        defaults={
+            "root_page": root_page,
+            "is_default_site": True,
+            "site_name": "Test Site",
+        },
+    )
+    return site
+
+
+def _make_image(filename: str):
+    return get_image_model().objects.create(
+        title=filename,
+        file=get_test_image_file(filename=filename),
+    )
+
+
+class TestFaviconEndpoint:
+    @pytest.mark.django_db
+    def test_serves_configured_png_with_long_cache(self, client, default_site):
+        """FV1: GET /favicon.ico returns the configured PNG with a 1-year cache."""
+        SEOSettings.objects.create(
+            site=default_site, favicon_png=_make_image("favicon.png")
+        )
+
+        response = client.get("/favicon.ico")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert response["Cache-Control"] == ONE_YEAR_IMMUTABLE
+
+    @pytest.mark.django_db
+    def test_returns_404_when_not_configured(self, client, default_site):
+        """FV2: GET /favicon.ico returns 404 when no favicon is configured."""
+        SEOSettings.objects.create(site=default_site)
+
+        response = client.get("/favicon.ico")
+
+        assert response.status_code == 404
+
+
+class TestFaviconSvgEndpoint:
+    @pytest.mark.django_db
+    def test_serves_configured_svg_with_long_cache(self, client, default_site):
+        """FV3: GET /favicon.svg serves the configured SVG favicon."""
+        SEOSettings.objects.create(
+            site=default_site, favicon_svg=_make_image("favicon.png")
+        )
+
+        response = client.get("/favicon.svg")
+
+        assert response.status_code == 200
+        assert response["Cache-Control"] == ONE_YEAR_IMMUTABLE
+
+    @pytest.mark.django_db
+    def test_returns_404_when_not_configured(self, client, default_site):
+        SEOSettings.objects.create(site=default_site)
+
+        assert client.get("/favicon.svg").status_code == 404
+
+
+class TestAppleTouchIconEndpoint:
+    @pytest.mark.django_db
+    def test_serves_configured_icon_with_long_cache(self, client, default_site):
+        """FV4: GET /apple-touch-icon.png serves the configured Apple touch icon."""
+        SEOSettings.objects.create(
+            site=default_site, apple_touch_icon=_make_image("apple.png")
+        )
+
+        response = client.get("/apple-touch-icon.png")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert response["Cache-Control"] == ONE_YEAR_IMMUTABLE
+
+    @pytest.mark.django_db
+    def test_returns_404_when_not_configured(self, client, default_site):
+        SEOSettings.objects.create(site=default_site)
+
+        assert client.get("/apple-touch-icon.png").status_code == 404

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -5,6 +5,8 @@ Tests for wagtail-herald template tags.
 from unittest.mock import PropertyMock, patch
 
 from django.template import Context, Template
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
 
 from wagtail_herald.models import SEOSettings
 from wagtail_herald.templatetags.wagtail_herald import (
@@ -156,6 +158,32 @@ class TestSeoHeadTemplateTag:
         html = template.render(context)
 
         assert 'name="twitter:site" content="@testhandle"' in html
+
+    def test_tag_renders_favicon_at_root_path_with_real_size(self, rf, site, db):
+        """Favicon link points to the stable /favicon.ico root path with the
+        image's real dimensions (not the old hardcoded 48x48)."""
+        favicon = get_image_model().objects.create(
+            title="favicon", file=get_test_image_file(filename="favicon.png")
+        )
+        SEOSettings.objects.create(site=site, favicon_png=favicon)
+
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        html = template.render(Context({"request": request, "page": MockPage()}))
+
+        expected_sizes = f"{favicon.width}x{favicon.height}"
+        assert f'sizes="{expected_sizes}"' in html
+        assert 'href="/favicon.ico"' in html
+        # 旧来の固定値・メディアURL直リンクが残っていないこと
+        assert 'sizes="48x48"' not in html
+        assert "/media/" not in html
 
     def test_tag_renders_robots_noindex(self, rf, site):
         """Test tag renders robots meta for noindex pages."""


### PR DESCRIPTION
## なぜ

Google 検索結果のファビコンが地球儀マークに戻る現象が定期的に起きていた。設定（`<link rel=icon>` の中身）は正しいのに発生する。

原因は配信のされ方：

1. **ルート `/favicon.ico` が 404** — Google のファビコン取得はルートの `/favicon.ico` を必ず探し、リトライにも寛容ではない。取得失敗が一度でもあると地球儀にフォールバックする（最頻出トリガー）。
2. **`<link>` が CMS のメディア URL を直接指していた** — 再アップロードでファイル名が変わり URL が 404 化する。エッジからも消えやすい。
3. **`sizes="48x48"` が固定値** — 実体が 192px でも 48x48 と詐称していた。

Google のファビコンクローラは数週間おきに「1回だけ」取りに来るため、その1回が上記要因で失敗すると次の再取得まで地球儀になる。これが「定期的に起きる」正体。

## なにを

`robots.txt` / `ads.txt` / `security.txt` と同じ「クローラ向けルートエンドポイント」のパターンに揃えて、ファビモンをルートで配信する。

- `/favicon.ico` `/favicon.svg` `/apple-touch-icon.png` を `wagtail_herald.urls` に追加。設定済みのファビコン画像を **1年・immutable キャッシュ**で返す。
- `seo_head.html` の `<link>` をこの恒久ルートパスに向け、CMS メディア直リンクをやめる（URL が常に不変になる）。
- PNG ファビコンの `sizes` を固定の 48x48 ではなく画像の実寸（`width`×`height`）に修正。

これで herald を使う全サイトで、ルート404・URL非恒久・寸法詐称の3要因がまとめて解消される。

## テスト

- 新規 `tests/test_favicon.py`（6件）: 各エンドポイントが設定時に 200＋長期キャッシュ、未設定時に 404 を返すこと。
- `tests/test_templatetags.py` に seo_head 出力テスト（1件）: `<link>` が `/favicon.ico` を指し、`sizes` が実寸になり、旧来の `48x48`・`/media/` 直リンクが残らないこと。
- 全 390 テスト緑 / `ruff check` / `ruff format --check` / `mypy src/` 通過。