### PR TITLE
release: v0.11.1 — seo_head コメント漏れの修正

### DIFF
--- a/src/wagtail_herald/templates/wagtail_herald/seo_head.html
+++ b/src/wagtail_herald/templates/wagtail_herald/seo_head.html
@@ -36,8 +36,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {% if twitter_image %}<meta name="twitter:image" content="{{ twitter_image }}">{% endif %}
 {% if twitter_image_alt %}<meta name="twitter:image:alt" content="{{ twitter_image_alt }}">{% endif %}
 
-{# Favicon — wagtail_herald.urls が恒久ルートパスで長期キャッシュ配信する。
-   CMS メディア URL（再アップロードで変わる）に依存させないことで地球儀化を防ぐ #}
+{# Favicon: wagtail_herald.urls が恒久ルートパスで長期キャッシュ配信し、CMS メディア依存を避けて地球儀化を防ぐ #}
 {% if favicon_svg %}<link rel="icon" type="image/svg+xml" href="/favicon.svg">{% endif %}
 {% if favicon_png %}<link rel="icon" type="image/png"{% if favicon_png_sizes %} sizes="{{ favicon_png_sizes }}"{% endif %} href="/favicon.ico">{% endif %}
 {% if apple_touch_icon %}<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">{% endif %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -185,6 +185,38 @@ class TestSeoHeadTemplateTag:
         assert 'sizes="48x48"' not in html
         assert "/media/" not in html
 
+    def test_tag_does_not_leak_template_comments(self, rf, site, db):
+        """seo_head の出力にテンプレートコメント/タグが漏れないこと。
+
+        Django の ``{# #}`` は 1 行限定で、複数行に書くと本文として描画され
+        head が壊れる。favicon を含む全分岐をオンにして漏れがないか検証する。
+        """
+        favicon = get_image_model().objects.create(
+            title="favicon", file=get_test_image_file(filename="favicon.png")
+        )
+        SEOSettings.objects.create(
+            site=site,
+            favicon_png=favicon,
+            favicon_svg=favicon,
+            apple_touch_icon=favicon,
+            gtm_container_id="GTM-TEST",
+        )
+
+        request = rf.get("/")
+        request.site = site
+
+        class MockPage:
+            title = "Test Page"
+            seo_title = ""
+            search_description = ""
+
+        template = Template("{% load wagtail_herald %}{% seo_head %}")
+        html = template.render(Context({"request": request, "page": MockPage()}))
+
+        assert "{#" not in html
+        assert "#}" not in html
+        assert "{%" not in html
+
     def test_tag_renders_robots_noindex(self, rf, site):
         """Test tag renders robots meta for noindex pages."""
         request = rf.get("/")


### PR DESCRIPTION
## v0.11.1 (patch)

0.11.0 で追加した favicon の複数行 `{# #}` コメントが全ページの `<head>` に漏れる不具合を修正（#132）。Django の `{# #}` は 1 行限定。

- favicon コメントを 1 行化
- seo_head 出力にコメント/タグが漏れないリグレッションテストを追加

Git Flow: develop → main リリースブランチ経由。