### PR TITLE
fix(gtm): gtm_server_container_url がカスタム配信パスをサポートするよう修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## Unreleased
 
 - **Breaking**: GTM headスニペットのテキスト構造が変わりました。Content-Security-Policy で `script-src 'sha256-...'` のようなハッシュ許可リストを使用している場合は、このインラインスクリプトのハッシュ値を再計算してください。
-- **BREAKING CHANGE**: `gtm_server_container_url` の意味を変更しました。v0.12.0 では「ホスト名」を指定していましたが、v0.13.0 では「完全な配信パスのURL」を指定してください。例: 旧形式 `https://your-domain.com` -> 新形式 `https://your-domain.com/aBcDeFgHiJ/`
+- **BREAKING CHANGE**: `gtm_server_container_url` の意味を変更しました。v0.12.0 では「ホスト名」を指定していましたが、v0.13.0 では「完全な配信パスのURL」を指定してください。例: 旧形式 `https://your-domain.com` -> 新形式 `https://your-domain.com/aBcDeFgHiJ/`。また、`noscript` iframe は常に `https://www.googletagmanager.com/ns.html` を指すようになりました。v0.12.0 で `gtm_server_container_url` を設定していた場合も、server URL が使われるのは head の script のみです。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - **Breaking**: GTM headスニペットのテキスト構造が変わりました。Content-Security-Policy で `script-src 'sha256-...'` のようなハッシュ許可リストを使用している場合は、このインラインスクリプトのハッシュ値を再計算してください。
+- **BREAKING CHANGE**: `gtm_server_container_url` の意味を変更しました。v0.12.0 では「ホスト名」を指定していましたが、v0.13.0 では「完全な配信パスのURL」を指定してください。例: 旧形式 `https://your-domain.com` -> 新形式 `https://your-domain.com/aBcDeFgHiJ/`

--- a/src/wagtail_herald/models/settings.py
+++ b/src/wagtail_herald/models/settings.py
@@ -167,8 +167,11 @@ class SEOSettings(BaseSiteSetting):
         _("GTM Server Container URL"),
         blank=True,
         help_text=_(
-            "Server-side GTM container URL. When set, GTM scripts will be "
-            "loaded from this URL instead of www.googletagmanager.com. "
+            "Complete server-side GTM serving path URL. When set, GTM head "
+            "scripts will be loaded from this full path instead of "
+            "www.googletagmanager.com. Include the full path "
+            "(for example, https://your-domain.com/aBcDeFgHiJ/). "
+            "The trailing slash is required. "
             "Leave empty to use default Google Tag Manager."
         ),
     )

--- a/src/wagtail_herald/templates/wagtail_herald/seo_body.html
+++ b/src/wagtail_herald/templates/wagtail_herald/seo_body.html
@@ -1,6 +1,6 @@
 {# Google Tag Manager (noscript) - must be placed immediately after opening <body> tag #}
 {% if gtm_container_id %}
-<noscript><iframe src="{{ gtm_server_base_url }}/ns.html?id={{ gtm_container_id }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_container_id }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 {% endif %}
 

--- a/src/wagtail_herald/templates/wagtail_herald/seo_head.html
+++ b/src/wagtail_herald/templates/wagtail_herald/seo_head.html
@@ -1,10 +1,17 @@
 {# Google Tag Manager - must be placed as high as possible in <head> #}
 {% if gtm_container_id %}
+{% if gtm_script_url %}
+<script>(function(w,d,s,l,i,u){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s);j.async=true;j.src=u;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ gtm_container_id }}','{{ gtm_script_url|escapejs }}');</script>
+{% else %}
 <script>(function(w,d,s,l,i,u){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 u + '/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{ gtm_container_id }}','{{ gtm_server_base_url|escapejs }}');</script>
+{% endif %}
 {% endif %}
 
 {# Basic Meta #}

--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -36,11 +36,6 @@ def _should_exclude_gtm(request: HttpRequest | None) -> bool:
     return getattr(user, "is_staff", False)
 
 
-def _get_gtm_server_base_url(settings: SEOSettings | None) -> str:
-    """Return the GTM server base URL without a trailing slash."""
-    return "https://www.googletagmanager.com"
-
-
 def _get_gtm_script_url(settings: SEOSettings | None) -> str:
     """Return the custom server-side GTM script URL with a trailing slash."""
     if settings and settings.gtm_server_container_url:
@@ -286,7 +281,6 @@ def seo_body(context: dict[str, Any]) -> SafeString:
 
     body_context = {
         "gtm_container_id": gtm_id,
-        "gtm_server_base_url": _get_gtm_server_base_url(seo_settings),
         "custom_body_end_html": seo_settings.custom_body_end_html
         if seo_settings
         else "",
@@ -919,7 +913,7 @@ def build_seo_context(
         "gtm_container_id": ""
         if _should_exclude_gtm(request)
         else (settings.gtm_container_id if settings else ""),
-        "gtm_server_base_url": _get_gtm_server_base_url(settings),
+        "gtm_server_base_url": "https://www.googletagmanager.com",
         "gtm_script_url": _get_gtm_script_url(settings),
         "custom_head_html": settings.custom_head_html if settings else "",
         "hreflang_links": page.get_hreflang_links()

--- a/src/wagtail_herald/templatetags/wagtail_herald.py
+++ b/src/wagtail_herald/templatetags/wagtail_herald.py
@@ -38,9 +38,14 @@ def _should_exclude_gtm(request: HttpRequest | None) -> bool:
 
 def _get_gtm_server_base_url(settings: SEOSettings | None) -> str:
     """Return the GTM server base URL without a trailing slash."""
-    if settings and settings.gtm_server_container_url:
-        return settings.gtm_server_container_url.rstrip("/")
     return "https://www.googletagmanager.com"
+
+
+def _get_gtm_script_url(settings: SEOSettings | None) -> str:
+    """Return the custom server-side GTM script URL with a trailing slash."""
+    if settings and settings.gtm_server_container_url:
+        return f"{settings.gtm_server_container_url.rstrip('/')}/"
+    return ""
 
 
 def get_seo_settings(request: HttpRequest | None) -> SEOSettings | None:
@@ -915,6 +920,7 @@ def build_seo_context(
         if _should_exclude_gtm(request)
         else (settings.gtm_container_id if settings else ""),
         "gtm_server_base_url": _get_gtm_server_base_url(settings),
+        "gtm_script_url": _get_gtm_script_url(settings),
         "custom_head_html": settings.custom_head_html if settings else "",
         "hreflang_links": page.get_hreflang_links()
         if page and hasattr(page, "get_hreflang_links")

--- a/tests/integration/test_exclude_staff_gtm.py
+++ b/tests/integration/test_exclude_staff_gtm.py
@@ -16,6 +16,7 @@ from wagtail_herald.models import SEOSettings
 GTM_CONTAINER_ID = "GTM-TEST117"
 GTM_JS_MARKER = "gtm.js"
 GTM_NS_MARKER = "googletagmanager.com/ns.html"
+GTM_SERVER_SCRIPT_URL = "https://gtm.example.com/aBcDeFgHiJ/"
 
 
 @pytest.fixture
@@ -389,3 +390,25 @@ class TestSeoHeadAndBodyGtmConsistency:
         assert GTM_CONTAINER_ID in head_part
         assert GTM_NS_MARKER in body_part
         assert GTM_CONTAINER_ID in body_part
+
+    @pytest.mark.django_db
+    def test_server_container_url_affects_head_script_only(
+        self, rf, _site, seo_settings, normal_user, mock_page
+    ):
+        """Server-side GTM URL is used only for the head script."""
+        seo_settings.gtm_server_container_url = GTM_SERVER_SCRIPT_URL
+        seo_settings.save()
+
+        request = _build_request(rf, _site, normal_user)
+        template = Template(
+            "{% load wagtail_herald %}{% seo_head %}<!-- sep -->{% seo_body %}"
+        )
+        context = Context({"request": request, "page": mock_page})
+
+        html = template.render(context)
+
+        head_part, body_part = html.split("<!-- sep -->")
+        assert GTM_SERVER_SCRIPT_URL in head_part
+        assert "/gtm.js?id=" not in head_part
+        assert GTM_NS_MARKER in body_part
+        assert GTM_SERVER_SCRIPT_URL not in body_part

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -2454,11 +2454,11 @@ class TestSeoBodyTemplateTag:
         assert 'style="display:none;visibility:hidden"' in html
 
     def test_tag_renders_gtm_noscript_with_server_container_url(self, rf, site, db):
-        """Test seo_body renders GTM noscript with server container URL when configured."""
+        """Test seo_body keeps default GTM noscript URL when server URL is set."""
         SEOSettings.objects.create(
             site=site,
             gtm_container_id="GTM-TEST123",
-            gtm_server_container_url="https://gtm.example.com",
+            gtm_server_container_url="https://gtm.example.com/aBcDeFgHiJ/",
         )
 
         request = rf.get("/")
@@ -2469,10 +2469,9 @@ class TestSeoBodyTemplateTag:
         html = template.render(context)
 
         assert "<noscript>" in html
-        assert "gtm.example.com/ns.html?id=GTM-TEST123" in html
+        assert "googletagmanager.com/ns.html?id=GTM-TEST123" in html
         assert 'style="display:none;visibility:hidden"' in html
-        # Ensure default URL is NOT used
-        assert "www.googletagmanager.com/ns.html" not in html
+        assert "gtm.example.com" not in html
 
     def test_tag_renders_default_gtm_noscript_when_server_url_empty(self, rf, site, db):
         """Test seo_body renders default GTM noscript when server container URL is not set."""
@@ -2493,12 +2492,12 @@ class TestSeoBodyTemplateTag:
         assert "googletagmanager.com/ns.html?id=GTM-TEST123" in html
         assert 'style="display:none;visibility:hidden"' in html
 
-    def test_tag_handles_server_url_with_trailing_slash(self, rf, site, db):
-        """Test seo_body handles server container URL with trailing slash."""
+    def test_tag_ignores_server_url_with_trailing_slash(self, rf, site, db):
+        """Test seo_body ignores server container URL with trailing slash."""
         SEOSettings.objects.create(
             site=site,
             gtm_container_id="GTM-TEST123",
-            gtm_server_container_url="https://gtm.example.com/",
+            gtm_server_container_url="https://gtm.example.com/aBcDeFgHiJ/",
         )
 
         request = rf.get("/")
@@ -2509,9 +2508,8 @@ class TestSeoBodyTemplateTag:
         html = template.render(context)
 
         assert "<noscript>" in html
-        assert "gtm.example.com/ns.html?id=GTM-TEST123" in html
-        # Ensure no double slashes in URL
-        assert "example.com//ns.html" not in html
+        assert "googletagmanager.com/ns.html?id=GTM-TEST123" in html
+        assert "gtm.example.com" not in html
 
     def test_tag_empty_when_no_gtm(self, rf, site, db):
         """Test seo_body returns empty when GTM not configured."""
@@ -2593,11 +2591,11 @@ class TestGtmInSeoHead:
         assert "dataLayer" in html
 
     def test_seo_head_renders_gtm_server_container_url_when_set(self, rf, site, db):
-        """Test seo_head renders GTM script with server container URL when configured."""
+        """Test seo_head renders complete server-side GTM script URL as-is."""
         SEOSettings.objects.create(
             site=site,
             gtm_container_id="GTM-ABC123",
-            gtm_server_container_url="https://gtm.example.com",
+            gtm_server_container_url="https://gtm.example.com/aBcDeFgHiJ/",
         )
 
         request = rf.get("/")
@@ -2607,11 +2605,11 @@ class TestGtmInSeoHead:
         context = Context({"request": request})
         html = template.render(context)
 
-        assert "https://gtm.example.com" in html
+        assert "https://gtm.example.com/aBcDeFgHiJ/" in html
         assert "GTM-ABC123" in html
         assert "dataLayer" in html
-        # Ensure default URL is NOT used
         assert "www.googletagmanager.com" not in html
+        assert "/gtm.js?id=" not in html
 
     def test_seo_head_renders_default_gtm_when_server_url_empty(self, rf, site, db):
         """Test seo_head uses default GTM URL when server container URL is not set."""
@@ -2632,12 +2630,12 @@ class TestGtmInSeoHead:
         assert "GTM-ABC123" in html
         assert "dataLayer" in html
 
-    def test_seo_head_handles_server_url_with_trailing_slash(self, rf, site, db):
-        """Test seo_head handles server container URL with trailing slash."""
+    def test_seo_head_adds_trailing_slash_to_server_url(self, rf, site, db):
+        """Test seo_head adds trailing slash to complete server-side GTM URL."""
         SEOSettings.objects.create(
             site=site,
             gtm_container_id="GTM-ABC123",
-            gtm_server_container_url="https://gtm.example.com/",
+            gtm_server_container_url="https://gtm.example.com/aBcDeFgHiJ",
         )
 
         request = rf.get("/")
@@ -2647,11 +2645,10 @@ class TestGtmInSeoHead:
         context = Context({"request": request})
         html = template.render(context)
 
-        # Should render correctly without double slashes
-        assert "https://gtm.example.com" in html
+        assert "https://gtm.example.com/aBcDeFgHiJ/" in html
         assert "GTM-ABC123" in html
-        # Ensure no double slashes in URL
-        assert "example.com//gtm.js" not in html
+        assert "https://gtm.example.com/aBcDeFgHiJ/gtm.js" not in html
+        assert "/gtm.js?id=" not in html
 
     def test_seo_head_no_gtm_when_empty(self, rf, site, db):
         """Test seo_head doesn't render GTM when not configured."""
@@ -2671,7 +2668,7 @@ class TestGtmInSeoHead:
         settings = SEOSettings.objects.create(
             site=site,
             gtm_container_id="GTM-XYZ789",
-            gtm_server_container_url="https://gtm.example.com",
+            gtm_server_container_url="https://gtm.example.com/aBcDeFgHiJ",
         )
 
         request = rf.get("/")
@@ -2680,7 +2677,8 @@ class TestGtmInSeoHead:
         result = build_seo_context(request, None, settings)
 
         assert result["gtm_container_id"] == "GTM-XYZ789"
-        assert result["gtm_server_base_url"] == "https://gtm.example.com"
+        assert result["gtm_server_base_url"] == "https://www.googletagmanager.com"
+        assert result["gtm_script_url"] == "https://gtm.example.com/aBcDeFgHiJ/"
 
     def test_build_seo_context_empty_gtm(self, rf, site, db):
         """Test build_seo_context handles empty gtm_container_id."""
@@ -2693,6 +2691,7 @@ class TestGtmInSeoHead:
 
         assert result["gtm_container_id"] == ""
         assert result["gtm_server_base_url"] == "https://www.googletagmanager.com"
+        assert result["gtm_script_url"] == ""
 
 
 class TestGetSchemaLanguageHelper:


### PR DESCRIPTION
## 概要

v0.12.0で追加した`gtm_server_container_url`の設計に誤りがあった。「ホスト名だけ差し替え、`/gtm.js?id=...`というパスは維持する」という前提だったが、実機検証(Googleの公式サーバーサイドGTMコンテナ)で、実際の配信パスはランダム生成の完全なURL(末尾スラッシュ必須、クエリパラメータなし)だと判明した。

Closes #137

## 変更内容

- `gtm_server_container_url`の意味を「ベースURL」から「完全な配信URL」に変更(そのままscript srcに使う、末尾スラッシュは自動補完)
- noscript(`ns.html`)のリダイレクト処理を撤回し、常に`www.googletagmanager.com/ns.html?id=...`を指すようにした(このGoogle機能はnoscriptのファーストパーティ配信自体をサポートしていないため、元々機能していなかった)
- help_textを新仕様に合わせて更新
- CHANGELOGに破壊的変更として記載

## テスト

485テスト全て通過、ruff通過